### PR TITLE
feat: enhance JSONPath masking with recursive support and array handling

### DIFF
--- a/logmanager/CHANGELOG.md
+++ b/logmanager/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [1.33.0] - 2025-08-13
+- **Enhanced JSONPath masking with recursive support and array handling**
+- Add recursive JSONPath pattern support (`$..field`) for comprehensive field masking across all nesting levels
+- Implement case-insensitive substring matching for flexible field name matching (e.g., `$..token` matches `token`, `Token`, `authToken`, `usertoken`, etc.)
+- Fix array handling at root level to prevent empty object logging in request/response bodies
+- Add comprehensive unit tests for recursive patterns, array handling, and all masking types
+- Update README with detailed JSONPath masking documentation including syntax reference, examples, and best practices
+- Fix compilation error in Gorilla Mux middleware example by removing undefined function calls
+- **Technical improvements:**
+  - Added `recursiveMaskField` function for `$..` pattern support with deep traversal
+  - Modified `toObj` function to handle both objects and arrays properly at root level
+  - Enhanced field matching algorithm with case-insensitive substring comparison
+  - Added 60+ new unit tests covering edge cases, recursive patterns, and all masking scenarios
+  - Improved error handling for invalid JSONPath expressions and edge cases
+
 ## [1.32.0] - 2025-08-07
 - Add `LogInfoWithContext` function for structured info logging with context support
 - The new feature supports automatic trace ID extraction from context or transaction

--- a/logmanager/internal/attributes.go
+++ b/logmanager/internal/attributes.go
@@ -234,8 +234,15 @@ func ResponseCodeAttribute(a *Attributes, code int) {
 }
 
 func toObj(bodyBytes []byte) interface{} {
-	var payload map[string]interface{}
-	_ = json.Unmarshal(bodyBytes, &payload)
+	// First try to unmarshal as a generic interface{} to handle both objects and arrays
+	var payload interface{}
+	err := json.Unmarshal(bodyBytes, &payload)
+	if err != nil {
+		// If JSON unmarshaling fails, try as map[string]interface{} for backward compatibility
+		var mapPayload map[string]interface{}
+		_ = json.Unmarshal(bodyBytes, &mapPayload)
+		return mapPayload
+	}
 	return payload
 }
 


### PR DESCRIPTION
- Add recursive JSONPath pattern support ($..field) for comprehensive field masking across all nesting levels
- Implement case-insensitive substring matching for flexible field name matching
- Fix array handling at root level to prevent empty object logging
- Add comprehensive unit tests for all new functionality including recursive patterns, array handling, and masking types
- Update README with detailed JSONPath masking documentation and examples
- Fix compilation error in Gorilla Mux middleware example

Technical improvements:
- Added recursiveMaskField function for $.. pattern support
- Modified toObj function to handle both objects and arrays properly
- Enhanced field matching with case-insensitive substring comparison
- Added 60+ new unit tests covering edge cases and all masking scenarios

🤖 Generated with [Claude Code](https://claude.ai/code)