### PR TITLE
Simplify GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -4,11 +4,6 @@ title: "[Bug]: "
 labels: ["bug", "triage"]
 assignees: []
 body:
-  - type: markdown
-    attributes:
-      value: |
-        Thanks for taking the time to fill out this bug report!
-
   - type: dropdown
     id: module
     attributes:
@@ -24,75 +19,28 @@ body:
     validations:
       required: true
 
-  - type: input
-    id: version
-    attributes:
-      label: Version
-      description: What version of the module are you using?
-      placeholder: e.g., v1.2.3
-    validations:
-      required: true
-
   - type: textarea
-    id: what-happened
+    id: description
     attributes:
-      label: What happened?
-      description: Also tell us, what did you expect to happen?
-      placeholder: Tell us what you see!
-      value: "A bug happened!"
-    validations:
-      required: true
-
-  - type: textarea
-    id: reproduction
-    attributes:
-      label: Steps to Reproduce
-      description: Please provide steps to reproduce the issue
+      label: Bug Description
+      description: Describe the bug, expected behavior, steps to reproduce, and any relevant information
       placeholder: |
-        1. Go to '...'
-        2. Click on '....'
-        3. Scroll down to '....'
-        4. See error
+        **What happened:**
+        Describe the bug...
+
+        **Expected behavior:**
+        What you expected to happen...
+
+        **Steps to reproduce:**
+        1. ...
+        2. ...
+
+        **Environment:**
+        - Module version: v1.2.3
+        - Go version: go1.23.0
+        - OS: macOS 14.0
+
+        **Additional context:**
+        Any other information...
     validations:
       required: true
-
-  - type: textarea
-    id: logs
-    attributes:
-      label: Relevant log output
-      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
-      render: shell
-
-  - type: input
-    id: go-version
-    attributes:
-      label: Go Version
-      description: What version of Go are you running?
-      placeholder: e.g., go1.23.0
-    validations:
-      required: true
-
-  - type: input
-    id: os
-    attributes:
-      label: Operating System
-      description: What operating system are you using?
-      placeholder: e.g., macOS 14.0, Ubuntu 22.04, Windows 11
-    validations:
-      required: true
-
-  - type: textarea
-    id: additional-context
-    attributes:
-      label: Additional Context
-      description: Add any other context about the problem here
-      placeholder: Any additional information that might be helpful
-
-  - type: checkboxes
-    id: terms
-    attributes:
-      label: Code of Conduct
-      description: By submitting this issue, you agree to follow our Code of Conduct
-      options:
-        - label: I agree to follow this project's Code of Conduct
-          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -4,11 +4,6 @@ title: "[Feature]: "
 labels: ["enhancement", "triage"]
 assignees: []
 body:
-  - type: markdown
-    attributes:
-      value: |
-        Thanks for suggesting a new feature! Please fill out the form below.
-
   - type: dropdown
     id: module
     attributes:
@@ -26,79 +21,24 @@ body:
       required: true
 
   - type: textarea
-    id: problem
+    id: description
     attributes:
-      label: Is your feature request related to a problem?
-      description: A clear and concise description of what the problem is
-      placeholder: I'm always frustrated when...
-    validations:
-      required: false
-
-  - type: textarea
-    id: solution
-    attributes:
-      label: Describe the solution you'd like
-      description: A clear and concise description of what you want to happen
-      placeholder: I would like to see...
-    validations:
-      required: true
-
-  - type: textarea
-    id: alternatives
-    attributes:
-      label: Describe alternatives you've considered
-      description: A clear and concise description of any alternative solutions or features you've considered
-      placeholder: I've considered...
-    validations:
-      required: false
-
-  - type: textarea
-    id: use-case
-    attributes:
-      label: Use Case
-      description: Describe your use case for this feature
+      label: Feature Description
+      description: Describe the feature you'd like, the problem it solves, and how you'd use it
       placeholder: |
-        Example:
-        - As a developer, I want to...
-        - So that I can...
+        **Problem:**
+        Describe the problem or need...
+
+        **Proposed solution:**
+        Describe the feature you'd like...
+
+        **Use case:**
+        How would you use this feature?
+
+        **Alternatives considered:**
+        Other approaches you've thought about...
+
+        **Additional context:**
+        Any other information...
     validations:
       required: true
-
-  - type: dropdown
-    id: priority
-    attributes:
-      label: Priority
-      description: How important is this feature to you?
-      options:
-        - Low - Nice to have
-        - Medium - Would be helpful
-        - High - Important for my project
-        - Critical - Blocking my project
-    validations:
-      required: true
-
-  - type: checkboxes
-    id: contribution
-    attributes:
-      label: Contribution
-      description: Are you willing to contribute to this feature?
-      options:
-        - label: I would be willing to implement this feature
-        - label: I would be willing to help test this feature
-        - label: I would be willing to write documentation for this feature
-
-  - type: textarea
-    id: additional-context
-    attributes:
-      label: Additional Context
-      description: Add any other context, screenshots, or examples about the feature request here
-      placeholder: Any additional information that might be helpful
-
-  - type: checkboxes
-    id: terms
-    attributes:
-      label: Code of Conduct
-      description: By submitting this issue, you agree to follow our Code of Conduct
-      options:
-        - label: I agree to follow this project's Code of Conduct
-          required: true

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -4,11 +4,6 @@ title: "[Question]: "
 labels: ["question", "help wanted"]
 assignees: []
 body:
-  - type: markdown
-    attributes:
-      value: |
-        Thanks for reaching out! Please fill out the form below to help us understand your question.
-
   - type: dropdown
     id: module
     attributes:
@@ -24,99 +19,31 @@ body:
     validations:
       required: true
 
-  - type: dropdown
-    id: question-type
-    attributes:
-      label: Question Type
-      description: What type of question is this?
-      options:
-        - How to use / Implementation help
-        - Best practices
-        - Configuration help
-        - Integration with other libraries
-        - Performance optimization
-        - Documentation clarification
-        - Other
-    validations:
-      required: true
-
   - type: textarea
-    id: question
+    id: description
     attributes:
-      label: Your Question
-      description: Please describe your question in detail
-      placeholder: What would you like to know?
-    validations:
-      required: true
-
-  - type: textarea
-    id: context
-    attributes:
-      label: Context
-      description: Provide any relevant context about your project or use case
+      label: Question
+      description: Describe your question, what you're trying to achieve, and any relevant context
       placeholder: |
-        - What are you trying to achieve?
-        - What have you tried so far?
-        - Any relevant project details
-    validations:
-      required: false
+        **Question:**
+        What would you like to know?
 
-  - type: textarea
-    id: code-example
-    attributes:
-      label: Code Example (if applicable)
-      description: Please provide any relevant code snippets
-      render: go
-      placeholder: |
+        **Context:**
+        What are you trying to achieve?
+
+        **What I've tried:**
+        What have you tried so far?
+
+        **Code example (if applicable):**
+        ```go
         // Your code here
-        package main
+        ```
 
-        import "fmt"
+        **Environment (if relevant):**
+        - Go version: go1.23.0
+        - OS: macOS 14.0
 
-        func main() {
-            fmt.Println("Hello, World!")
-        }
-
-  - type: input
-    id: go-version
-    attributes:
-      label: Go Version
-      description: What version of Go are you using?
-      placeholder: e.g., go1.23.0
+        **Additional information:**
+        Any other details...
     validations:
-      required: false
-
-  - type: input
-    id: os
-    attributes:
-      label: Operating System
-      description: What operating system are you using?
-      placeholder: e.g., macOS 14.0, Ubuntu 22.04, Windows 11
-    validations:
-      required: false
-
-  - type: textarea
-    id: additional-info
-    attributes:
-      label: Additional Information
-      description: Any other information that might be helpful
-      placeholder: Any other details you think might be relevant
-
-  - type: checkboxes
-    id: research
-    attributes:
-      label: Research Done
-      description: Have you checked the following resources?
-      options:
-        - label: I have read the relevant documentation
-        - label: I have searched existing issues
-        - label: I have checked the examples directory
-
-  - type: checkboxes
-    id: terms
-    attributes:
-      label: Code of Conduct
-      description: By submitting this issue, you agree to follow our Code of Conduct
-      options:
-        - label: I agree to follow this project's Code of Conduct
-          required: true
+      required: true


### PR DESCRIPTION
## Summary
Simplified GitHub issue templates to reduce friction for users creating issues.

## Changes
- **Bug Report**: Reduced from 10+ fields to 2 fields (module dropdown + description textarea)
- **Feature Request**: Reduced from 8+ fields to 2 fields (module dropdown + description textarea)  
- **Question**: Reduced from 9+ fields to 2 fields (module dropdown + description textarea)

## Implementation
Each template now has:
1. **Module dropdown** (required) - Select affected module
2. **Single textarea** (required) - Free-form description with helpful placeholder text

The placeholder text provides structured guidance prompting users to include:
- Bug reports: What happened, expected behavior, steps to reproduce, environment
- Feature requests: Problem, proposed solution, use case, alternatives
- Questions: Question, context, what they've tried, code examples

## Benefits
- Faster issue creation with less form fatigue
- More flexible for users who want to provide information in their own way
- Maintains helpful guidance through placeholder text
- Reduced from 237 lines to 52 lines of template code

## Testing
- [ ] Verified YAML syntax is valid
- [ ] Tested template rendering on GitHub (after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)