### PR TITLE
fix: [zazin][AB-24] Add transaction to c.Request.Context() in Gin middleware for context propagation

### DIFF
--- a/logmanager/CHANGELOG.md
+++ b/logmanager/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+## [1.37.0] - 2025-10-10
+- **Fix Gin middleware to propagate transaction to c.Request.Context() (#24)**
+  - Transaction is now accessible from `c.Request.Context()` using `logmanager.FromContext(ctx)`
+  - Enables downstream layers (service, repository, domain) to access transaction without Gin context
+  - Uses existing `RequestWithTransactionContext` helper for proper context propagation
+  - Add comprehensive test case `TestMiddleware_TransactionInRequestContext` to verify fix
+  - Maintains backward compatibility: transaction still accessible via Gin context
+  - All existing tests pass with no regressions
+
 ## [1.36.0] - 2025-10-07
 - **Implement missing gRPC client and stream interceptors (#19)**
   - Add `UnaryClientInterceptor` for client-side unary RPC logging with automatic trace ID propagation

--- a/logmanager/integrations/lmgin/middleware.go
+++ b/logmanager/integrations/lmgin/middleware.go
@@ -36,6 +36,9 @@ func Middleware(app *logmanager.Application) gin.HandlerFunc {
 
 		c.Set(logmanager.TransactionContextKey.String(), tx)
 
+		// Also propagate transaction to c.Request.Context() for downstream layers
+		c.Request = logmanager.RequestWithTransactionContext(c.Request, tx)
+
 		rw := &responseCapture{Body: new(bytes.Buffer), ResponseWriter: c.Writer}
 		rw.Header().Set(app.TraceIDHeaderKey(), traceID)
 		c.Writer = rw


### PR DESCRIPTION
## Summary
- Fixed Gin middleware to propagate transaction to `c.Request.Context()`
- Downstream layers can now access transaction via `logmanager.FromContext(ctx)`
- Maintains backward compatibility with Gin context access

## Problem
Previously, the transaction was only stored in Gin context using:
```go
c.Set(logmanager.TransactionContextKey.String(), tx)
```

This meant downstream layers (service, repository, domain) that only receive `context.Context` couldn't access the transaction:
```go
func (s *MyService) DoSomething(ctx context.Context) {
    tx := logmanager.FromContext(ctx) // Returns nil ❌
}
```

## Solution
Extended the middleware to also attach transaction to `c.Request.Context()`:
```go
c.Request = logmanager.RequestWithTransactionContext(c.Request, tx)
```

Now both access methods work:
```go
// Gin context (existing)
tx, _ := c.Get(logmanager.TransactionContextKey.String())

// Go context (new)
tx := logmanager.FromContext(c.Request.Context())
```

## Changes
- Modified `logmanager/integrations/lmgin/middleware.go:40` to propagate transaction to request context
- Added test case `TestMiddleware_TransactionInRequestContext` to verify fix
- Updated CHANGELOG.md with version 1.37.0

## Test Results
All tests pass including the new test that verifies transaction accessibility from request context:
```
=== RUN   TestMiddleware_TransactionInRequestContext
--- PASS: TestMiddleware_TransactionInRequestContext (0.00s)
PASS
ok  	github.com/SALT-Indonesia/salt-pkg/logmanager/integrations/lmgin	0.009s
```

## Backward Compatibility
✅ All existing tests pass
✅ Transaction still accessible via Gin context
✅ No breaking changes

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)