### PR TITLE
feat: [zazin] Upgrade clientmanager logmanager to v1.38.1 with EmailMask support

### DIFF
--- a/clientmanager/go.mod
+++ b/clientmanager/go.mod
@@ -6,7 +6,7 @@ toolchain go1.23.4
 
 require (
 	github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358
-	github.com/SALT-Indonesia/salt-pkg/logmanager v1.34.0
+	github.com/SALT-Indonesia/salt-pkg/logmanager v1.38.1
 	github.com/aws/aws-sdk-go-v2 v1.38.2
 	github.com/aws/aws-sdk-go-v2/credentials v1.18.8
 	github.com/dghubble/oauth1 v0.7.3

--- a/clientmanager/go.sum
+++ b/clientmanager/go.sum
@@ -2,6 +2,8 @@ github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358 h1:mFRzDkZVAjdal+
 github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358/go.mod h1:chxPXzSsl7ZWRAuOIE23GDNzjWuZquvFlgA8xmpunjU=
 github.com/SALT-Indonesia/salt-pkg/logmanager v1.34.0 h1:Vu0wnKPcKbFrVl6zgQURAHzwQHPbZOKoHtKp/pb3tp8=
 github.com/SALT-Indonesia/salt-pkg/logmanager v1.34.0/go.mod h1:na+KCOW3Umy2zNWSirpanHIDweuEklxqI0yRp9gV0Qs=
+github.com/SALT-Indonesia/salt-pkg/logmanager v1.38.1 h1:G5Aq4CVzgC2X7JdYI6SFXWB4Og5tQ/Ev7ypzsxPCGHU=
+github.com/SALT-Indonesia/salt-pkg/logmanager v1.38.1/go.mod h1:na+KCOW3Umy2zNWSirpanHIDweuEklxqI0yRp9gV0Qs=
 github.com/aws/aws-sdk-go-v2 v1.36.3 h1:mJoei2CxPutQVxaATCzDUjcZEjVRdpsiiXi2o38yqWM=
 github.com/aws/aws-sdk-go-v2 v1.36.3/go.mod h1:LLXuLpgzEbD766Z5ECcRmi8AzSwfZItDtmABVkRLGzg=
 github.com/aws/aws-sdk-go-v2 v1.38.2 h1:QUkLO1aTW0yqW95pVzZS0LGFanL71hJ0a49w4TJLMyM=


### PR DESCRIPTION
## Summary
- Upgrade logmanager dependency from v1.34.0 to v1.38.1
- Enables `EmailMask` type for proper email address masking (preserves domain, masks username)
- Includes fix for JSONPath masking on non-struct types

## Changes
- `clientmanager/go.mod`: Updated logmanager version

## Test plan
- [x] All clientmanager tests pass
- [x] Lint passes (0 issues)
- [x] No breaking changes - dependency update only

🤖 Generated with [Claude Code](https://claude.com/claude-code)