### PR TITLE
feat: [zazin] Upgrade eventmanager logmanager to v1.38.1 with EmailMask support

### DIFF
--- a/eventmanager/go.mod
+++ b/eventmanager/go.mod
@@ -5,7 +5,7 @@ go 1.23.0
 toolchain go1.23.4
 
 require (
-	github.com/SALT-Indonesia/salt-pkg/logmanager v1.34.0
+	github.com/SALT-Indonesia/salt-pkg/logmanager v1.38.1
 	github.com/go-playground/validator/v10 v10.26.0
 	github.com/google/uuid v1.6.0
 	github.com/joho/godotenv v1.5.1

--- a/eventmanager/go.sum
+++ b/eventmanager/go.sum
@@ -1,5 +1,7 @@
 github.com/SALT-Indonesia/salt-pkg/logmanager v1.34.0 h1:Vu0wnKPcKbFrVl6zgQURAHzwQHPbZOKoHtKp/pb3tp8=
 github.com/SALT-Indonesia/salt-pkg/logmanager v1.34.0/go.mod h1:na+KCOW3Umy2zNWSirpanHIDweuEklxqI0yRp9gV0Qs=
+github.com/SALT-Indonesia/salt-pkg/logmanager v1.38.1 h1:G5Aq4CVzgC2X7JdYI6SFXWB4Og5tQ/Ev7ypzsxPCGHU=
+github.com/SALT-Indonesia/salt-pkg/logmanager v1.38.1/go.mod h1:na+KCOW3Umy2zNWSirpanHIDweuEklxqI0yRp9gV0Qs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
## Summary
- Upgrade logmanager dependency from v1.34.0 to v1.38.1
- Enables `EmailMask` type for proper email address masking (preserves domain, masks username)
- Includes fix for JSONPath masking on non-struct types

## Changes
- `eventmanager/go.mod`: Updated logmanager version

## Test plan
- [x] All eventmanager tests pass
- [x] Lint passes (0 issues)
- [x] No breaking changes - dependency update only

🤖 Generated with [Claude Code](https://claude.com/claude-code)