### PR TITLE
chore: [zazin] Upgrade httpmanager logmanager to v1.38.2

### DIFF
--- a/httpmanager/go.mod
+++ b/httpmanager/go.mod
@@ -5,7 +5,7 @@ go 1.23.0
 toolchain go1.23.4
 
 require (
-	github.com/SALT-Indonesia/salt-pkg/logmanager v1.38.1
+	github.com/SALT-Indonesia/salt-pkg/logmanager v1.38.2
 	github.com/gorilla/mux v1.8.1
 	github.com/stretchr/testify v1.11.1
 )

--- a/httpmanager/go.sum
+++ b/httpmanager/go.sum
@@ -1,7 +1,5 @@
-github.com/SALT-Indonesia/salt-pkg/logmanager v1.35.0 h1:WnJ0gLdp2i+QZG2zeEewAt7HkqeDFL5wohqbiF5gp4g=
-github.com/SALT-Indonesia/salt-pkg/logmanager v1.35.0/go.mod h1:na+KCOW3Umy2zNWSirpanHIDweuEklxqI0yRp9gV0Qs=
-github.com/SALT-Indonesia/salt-pkg/logmanager v1.38.1 h1:G5Aq4CVzgC2X7JdYI6SFXWB4Og5tQ/Ev7ypzsxPCGHU=
-github.com/SALT-Indonesia/salt-pkg/logmanager v1.38.1/go.mod h1:na+KCOW3Umy2zNWSirpanHIDweuEklxqI0yRp9gV0Qs=
+github.com/SALT-Indonesia/salt-pkg/logmanager v1.38.2 h1:8//D3fkiO0G8uN6IXmnrlvkDN5qNpCrTQcYl46eCpSo=
+github.com/SALT-Indonesia/salt-pkg/logmanager v1.38.2/go.mod h1:na+KCOW3Umy2zNWSirpanHIDweuEklxqI0yRp9gV0Qs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
## Summary
- Upgrade logmanager dependency from v1.38.1 to v1.38.2
- v1.38.2 adds `Debug()` method to Application for exposing debug mode status

## Test plan
- [x] `go mod tidy` completed successfully
- [x] Dependency downloads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)