### PR TITLE
docs: [zazin] Add conditional middleware example for httpmanager

### DIFF
--- a/examples/httpmanager/cmd/conditional-middleware/main.go
+++ b/examples/httpmanager/cmd/conditional-middleware/main.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"examples/httpmanager/internal/delivery/protected"
+	"examples/httpmanager/internal/middleware"
+	"log"
+	"os"
+
+	"github.com/SALT-Indonesia/salt-pkg/httpmanager"
+	"github.com/SALT-Indonesia/salt-pkg/logmanager"
+	"github.com/gorilla/mux"
+)
+
+func main() {
+	app := logmanager.NewApplication(
+		logmanager.WithDebug(),
+		logmanager.WithAppName("conditional-middleware-example"),
+	)
+
+	server := httpmanager.NewServer(app)
+	server.EnableCORS(
+		[]string{"*"},
+		[]string{"GET", "POST", "PUT", "DELETE"},
+		[]string{"*"},
+		false,
+	)
+
+	// ============================================================
+	// CONDITIONAL MIDDLEWARE EXAMPLE
+	// ============================================================
+	//
+	// Problem: In production, Kong gateway handles token validation
+	// and sets X-User-* headers. In local environment, we need to
+	// validate tokens ourselves. This leads to duplicated route definitions:
+	//
+	//   if isLocal {
+	//       server.Handle("/users/me", handler.Use(KongAuth(ts), ExtractUser()).WithMiddleware())
+	//   } else {
+	//       server.Handle("/users/me", handler.Use(ExtractUser()).WithMiddleware())
+	//   }
+	//
+	// Solution: Build middleware array dynamically and pass to Use()
+
+	isLocal := os.Getenv("APP_ENV") == "local"
+	tokenService := &protected.MockTokenService{}
+
+	if isLocal {
+		log.Println("Mode: LOCAL - KongAuth middleware enabled")
+	} else {
+		log.Println("Mode: PRODUCTION - KongAuth middleware disabled (handled by gateway)")
+	}
+
+	// Build middleware array dynamically
+	middlewares := []mux.MiddlewareFunc{}
+	if isLocal {
+		middlewares = append(middlewares, middleware.KongAuth(tokenService))
+	}
+	middlewares = append(middlewares, middleware.ExtractUser())
+
+	// Clean approach: pass middleware array to Use()
+	server.Handle("/protected/me",
+		protected.NewGetProfileHandler().
+			Use(middlewares...).
+			WithMiddleware(),
+	)
+
+	log.Println("")
+	log.Println("Server starting on :8080")
+	log.Println("")
+	log.Println("Test commands:")
+	if isLocal {
+		log.Println("  curl -H 'Authorization: Bearer valid-token' http://localhost:8080/protected/me")
+		log.Println("  curl -H 'Authorization: Bearer invalid' http://localhost:8080/protected/me  # 401")
+	} else {
+		log.Println("  curl -H 'X-User-ID: user-123' -H 'X-User-Email: user@example.com' http://localhost:8080/protected/me")
+	}
+	log.Println("")
+	log.Println("To switch mode: APP_ENV=local go run main.go")
+
+	log.Panic(server.Start())
+}

--- a/examples/httpmanager/internal/delivery/protected/handlers.go
+++ b/examples/httpmanager/internal/delivery/protected/handlers.go
@@ -1,0 +1,56 @@
+package protected
+
+import (
+	"context"
+	"errors"
+	"examples/httpmanager/internal/middleware"
+	"fmt"
+
+	"github.com/SALT-Indonesia/salt-pkg/httpmanager"
+)
+
+// MockTokenService is a mock implementation for demonstration
+type MockTokenService struct{}
+
+func (m *MockTokenService) ValidateToken(token string) (*middleware.User, error) {
+	// In real implementation, this would validate JWT token
+	if token == "valid-token" {
+		return &middleware.User{
+			ID:    "user-123",
+			Email: "user@example.com",
+			Role:  "admin",
+		}, nil
+	}
+	return nil, errors.New("invalid token")
+}
+
+// Request/Response types
+type EmptyRequest struct{}
+
+type ProfileResponse struct {
+	ID    string `json:"id"`
+	Email string `json:"email"`
+	Role  string `json:"role"`
+}
+
+// NewGetProfileHandler returns a handler for GET /protected/me
+func NewGetProfileHandler() *httpmanager.Handler[EmptyRequest, ProfileResponse] {
+	return httpmanager.NewHandler("GET", func(ctx context.Context, _ *EmptyRequest) (*ProfileResponse, error) {
+		user := middleware.GetUser(ctx)
+		if user == nil {
+			return nil, &httpmanager.CustomError{
+				Err:        fmt.Errorf("user not found in context"),
+				Code:       "401",
+				Title:      "Unauthorized",
+				Desc:       "User not found",
+				StatusCode: 401,
+			}
+		}
+
+		return &ProfileResponse{
+			ID:    user.ID,
+			Email: user.Email,
+			Role:  user.Role,
+		}, nil
+	})
+}

--- a/examples/httpmanager/internal/middleware/conditional.go
+++ b/examples/httpmanager/internal/middleware/conditional.go
@@ -1,0 +1,94 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+// UserContextKey is the context key for user information
+type UserContextKey struct{}
+
+// User represents authenticated user information
+type User struct {
+	ID    string
+	Email string
+	Role  string
+}
+
+// TokenService interface for token validation
+type TokenService interface {
+	ValidateToken(token string) (*User, error)
+}
+
+// KongAuth validates the token using Kong gateway simulation.
+// In production, Kong handles this, but in local environment we need to validate manually.
+func KongAuth(tokenService TokenService) mux.MiddlewareFunc {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			token := r.Header.Get("Authorization")
+			if token == "" {
+				http.Error(w, "Unauthorized: missing token", http.StatusUnauthorized)
+				return
+			}
+
+			// Remove "Bearer " prefix if present
+			if len(token) > 7 && token[:7] == "Bearer " {
+				token = token[7:]
+			}
+
+			user, err := tokenService.ValidateToken(token)
+			if err != nil {
+				http.Error(w, "Unauthorized: invalid token", http.StatusUnauthorized)
+				return
+			}
+
+			// Add user to context
+			ctx := context.WithValue(r.Context(), UserContextKey{}, user)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
+
+// ExtractUser extracts user information from headers (set by Kong in production)
+// or from context (set by KongAuth middleware in local).
+// This middleware expects X-User-ID, X-User-Email headers to be present in production.
+func ExtractUser() mux.MiddlewareFunc {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Check if user already in context (from KongAuth middleware)
+			if user := r.Context().Value(UserContextKey{}); user != nil {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			// Extract from headers (production mode - Kong sets these)
+			userID := r.Header.Get("X-User-ID")
+			userEmail := r.Header.Get("X-User-Email")
+			userRole := r.Header.Get("X-User-Role")
+
+			if userID == "" {
+				http.Error(w, "Unauthorized: missing user information", http.StatusUnauthorized)
+				return
+			}
+
+			user := &User{
+				ID:    userID,
+				Email: userEmail,
+				Role:  userRole,
+			}
+
+			ctx := context.WithValue(r.Context(), UserContextKey{}, user)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
+
+// GetUser retrieves user information from context
+func GetUser(ctx context.Context) *User {
+	if user, ok := ctx.Value(UserContextKey{}).(*User); ok {
+		return user
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- Add example demonstrating conditional middleware pattern for httpmanager
- Show how to dynamically build middleware array based on environment (local vs production)
- Avoid duplicating route definitions when middleware varies by environment

## Pattern
```go
middlewares := []mux.MiddlewareFunc{}
if isLocal {
    middlewares = append(middlewares, middleware.KongAuth(tokenService))
}
middlewares = append(middlewares, middleware.ExtractUser())

server.Handle("/protected/me",
    handler.Use(middlewares...).WithMiddleware(),
)
```

## Test plan
- [x] Run example in production mode: `go run ./cmd/conditional-middleware/main.go`
- [x] Run example in local mode: `APP_ENV=local go run ./cmd/conditional-middleware/main.go`
- [x] Verify middleware is applied correctly in each mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)