### PR TITLE
feat: [logmanager] WithSkipHeaders option

### DIFF
--- a/examples/logmanager/07-skip-headers/main.go
+++ b/examples/logmanager/07-skip-headers/main.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/SALT-Indonesia/salt-pkg/logmanager"
+	"github.com/SALT-Indonesia/salt-pkg/logmanager/integrations/lmgin"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+const traceIDKey = "xid"
+
+func main() {
+	gin.SetMode(gin.ReleaseMode)
+
+	r := gin.New()
+
+	app := logmanager.NewApplication(
+		logmanager.WithAppName("skip-headers-example"),
+		logmanager.WithDebug(),
+		logmanager.WithSkipHeaders(),
+	)
+
+	r.Use(traceIDMiddleware(), lmgin.Middleware(app))
+
+	r.GET("/ping", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"message": "pong"})
+	})
+
+	fmt.Println("Server running at http://localhost:8007")
+	fmt.Println("Try: curl http://localhost:8007/ping")
+	fmt.Println("Notice: request headers will NOT appear in the logs (WithSkipHeaders enabled)")
+
+	if err := r.Run(":8007"); err != nil {
+		panic(err)
+	}
+}
+
+func traceIDMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Set(traceIDKey, uuid.NewString())
+		c.Next()
+	}
+}

--- a/logmanager/CHANGELOG.md
+++ b/logmanager/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 ## [Unreleased]
+- **Add `WithSkipHeaders()` option to disable request headers logging (#61)**
+  - New `WithSkipHeaders()` option that completely omits request headers from log output
+  - Reduces log volume in production environments where headers are not needed
+  - Add `skipHeaders` field to `Application` and `TxnRecord`
+  - Add `07-skip-headers` example demonstrating usage with Gin
+  - Add unit test for the new option
 
 ## [1.41.0] - 2026-02-12
 - **Fix nil pointer dereference when using transactions in async goroutines (#54)**

--- a/logmanager/app.go
+++ b/logmanager/app.go
@@ -27,6 +27,7 @@ type Application struct {
 	exposeHeaders     []string
 	traceIDKey        string
 	splitLevelOutput  bool
+	skipHeaders       bool
 	// OpenTelemetry fields
 	otelEnabled          bool
 	otelExporterOptions  []OTelExporterOption
@@ -226,6 +227,7 @@ func (app *Application) start(traceID string, name string, transactionType TxnTy
 		exposeHeaders: app.exposeHeaders,
 		debug:         app.debug,
 		traceIDKey:    app.traceIDKey,
+		skipHeaders:   app.skipHeaders,
 		otelSpan:      rootSpan,
 	}
 

--- a/logmanager/option.go
+++ b/logmanager/option.go
@@ -65,6 +65,14 @@ func WithTags(tags ...string) Option {
 	}
 }
 
+// WithSkipHeaders disables logging of request headers.
+// This is useful in production environments where header logging generates excessive log volume.
+func WithSkipHeaders() Option {
+	return func(app *Application) {
+		app.skipHeaders = true
+	}
+}
+
 // WithExposeHeaders configures the Application to expose specified headers in the response or request by setting exposeHeaders.
 func WithExposeHeaders(headers ...string) Option {
 	return func(app *Application) {

--- a/logmanager/option_test.go
+++ b/logmanager/option_test.go
@@ -78,6 +78,15 @@ func TestWithTags(t *testing.T) {
 	}
 }
 
+func TestWithSkipHeaders(t *testing.T) {
+	app := logmanager.NewApplication(logmanager.WithSkipHeaders())
+	assert.NotNil(t, app)
+
+	txn := app.StartHttp("test-trace", "test")
+	assert.NotNil(t, txn)
+	txn.End()
+}
+
 func TestWithExposeHeaders(t *testing.T) {
 	tests := []struct {
 		name            string

--- a/logmanager/txn_logging.go
+++ b/logmanager/txn_logging.go
@@ -68,14 +68,16 @@ func (txn *TxnRecord) extractValues() map[string]interface{} {
 		values["tags"] = txn.tags
 	}
 
-	headers := internal.Header{
-		Data:           internal.ToMapString(txn.attrs.Value().Get(internal.AttributeRequestHeaders)),
-		AllowedHeaders: txn.exposeHeaders,
-		IsDebugMode:    txn.debug || txn.exposeAllHeader,
-	}.FilterHeaders()
+	if !txn.skipHeaders {
+		headers := internal.Header{
+			Data:           internal.ToMapString(txn.attrs.Value().Get(internal.AttributeRequestHeaders)),
+			AllowedHeaders: txn.exposeHeaders,
+			IsDebugMode:    txn.debug || txn.exposeAllHeader,
+		}.FilterHeaders()
 
-	if len(headers) > 0 {
-		values[internal.AttributeRequestHeaders] = headers
+		if len(headers) > 0 {
+			values[internal.AttributeRequestHeaders] = headers
+		}
 	}
 
 	if txn.attrs.Value().IsNotEmpty(internal.AttributeRequestQueryParam) {

--- a/logmanager/txn_record.go
+++ b/logmanager/txn_record.go
@@ -23,6 +23,7 @@ type TxnRecord struct {
 	exposeHeaders             []string
 	traceIDKey                string
 	skipRequest, skipResponse bool
+	skipHeaders               bool
 	exposeAllHeader           bool
 	// OpenTelemetry span
 	otelSpan *otellog.Span


### PR DESCRIPTION
## Summary
- Add `WithSkipHeaders()` option to disable request headers logging in logmanager
- Useful for production environments where header logging generates excessive log volume

## Test plan
- [x] Unit test `TestWithSkipHeaders` added and passing
- [x] All existing logmanager tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)