### PR TITLE
feat: [clientmanager] Adds option to disable HTTP proxy

### DIFF
--- a/clientmanager/option.go
+++ b/clientmanager/option.go
@@ -345,3 +345,11 @@ func WithDisabledHTTP2() Option {
 		}
 	}
 }
+
+func WithNoProxy() Option {
+	return func(co *callOptions) {
+		if tr, ok := co.client.Transport.(*http.Transport); ok {
+			tr.Proxy = nil
+		}
+	}
+}


### PR DESCRIPTION
**Summary**  
- Add a `WithNoProxy()` option in clientmanager to bypass `http_proxy` for internal calls.  
- Use `WithNoProxy()` in Hydra introspect to avoid proxy routing that returns `503 no healthy upstream`.

**Changes**  
- Add `WithNoProxy()` option in option.go.  
- Apply `WithNoProxy()` in introspect_oauth_token.go.

**Why**  
`clientmanager` uses `ProxyFromEnvironment`. When `http_proxy` is set in the pod, internal ClusterIP calls are routed through the proxy/mesh and return `503 no healthy upstream`. Manual HTTP calls without proxy succeed. This change allows explicit opt‑out.

**Testing**  
- Deployed to UAT: introspection call succeeds with `WithNoProxy()` while preserving other settings.