### PR TITLE
test: [logmanager] high-traffic integration tests + fix concurrent fanout race

### DIFF
--- a/logmanager/integrations/lmecho/integration_test.go
+++ b/logmanager/integrations/lmecho/integration_test.go
@@ -1,0 +1,175 @@
+package lmecho_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/SALT-Indonesia/salt-pkg/logmanager"
+	"github.com/SALT-Indonesia/salt-pkg/logmanager/integrations/lmecho"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+// loggedTypes counts the captured log entries grouped by their "type" field.
+// Entries are produced both by the middleware (http) and by every nested
+// TxnRecord.End() call (api, database, other, ...).
+func loggedTypes(app *logmanager.TestableApplication) map[logmanager.TxnType]int {
+	counts := make(map[logmanager.TxnType]int)
+	for _, entry := range app.GetLoggedEntries() {
+		if v, ok := entry.Data["type"]; ok {
+			if t, ok := v.(logmanager.TxnType); ok {
+				counts[t]++
+			}
+		}
+	}
+	return counts
+}
+
+// fullProcessingHandler simulates a realistic REST handler that, while serving
+// one request, performs an outbound API call, a database query and some other
+// internal work — each producing its own log entry. The middleware produces the
+// http entry on tx.End().
+func fullProcessingHandler(c echo.Context) error {
+	tx := logmanager.FromContext(c.Request().Context())
+
+	apiTxn := tx.AddTxn("call-payment-api", logmanager.TxnTypeApi)
+	apiTxn.SetRequestValue(map[string]any{"order_id": c.Param("id")})
+	apiTxn.SetResponseValue(map[string]any{"status": "charged"})
+	apiTxn.End()
+
+	dbTxn := logmanager.StartDatabaseSegment(tx, logmanager.DatabaseSegment{
+		Name:  "select-orders",
+		Table: "orders",
+		Query: "SELECT * FROM orders WHERE id = ?",
+		Host:  "localhost",
+	})
+	dbTxn.End()
+
+	otherTxn := logmanager.StartOtherSegment(tx, logmanager.OtherSegment{
+		Name:  "compute-tax",
+		Extra: map[string]interface{}{"region": "ID"},
+	})
+	otherTxn.End()
+
+	return c.JSON(http.StatusOK, map[string]any{"message": "ok", "id": c.Param("id")})
+}
+
+func newRouter(app *logmanager.TestableApplication) *echo.Echo {
+	e := echo.New()
+	e.Use(lmecho.Middleware(app.Application))
+	e.GET("/orders/:id", fullProcessingHandler)
+	return e
+}
+
+// TestEchoAllLogTypesPresent proves that a single REST request emits every
+// expected transaction log type: http, api, database and other.
+func TestEchoAllLogTypesPresent(t *testing.T) {
+	app := logmanager.NewTestableApplication()
+	app.ResetLoggedEntries()
+	e := newRouter(app)
+
+	req := httptest.NewRequest(http.MethodGet, "/orders/123", nil)
+	w := httptest.NewRecorder()
+	e.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	counts := loggedTypes(app)
+	for _, want := range []logmanager.TxnType{
+		logmanager.TxnTypeHttp,
+		logmanager.TxnTypeApi,
+		logmanager.TxnTypeDatabase,
+		logmanager.TxnTypeOther,
+	} {
+		assert.GreaterOrEqual(t, counts[want], 1, "expected at least one %q log entry", want)
+	}
+
+	var traceID string
+	for _, entry := range app.GetLoggedEntries() {
+		got, _ := entry.Data["trace_id"].(string)
+		assert.NotEmpty(t, got, "trace_id should not be empty")
+		if traceID == "" {
+			traceID = got
+		} else {
+			assert.Equal(t, traceID, got, "all entries in a request should share trace_id")
+		}
+	}
+}
+
+// TestEchoConcurrentRequests drives many requests concurrently against the same
+// app/router to emulate high production traffic. Run with -race to surface any
+// shared-state data races across requests.
+func TestEchoConcurrentRequests(t *testing.T) {
+	const n = 200
+
+	app := logmanager.NewTestableApplication()
+	app.ResetLoggedEntries()
+	e := newRouter(app)
+
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			req := httptest.NewRequest(http.MethodGet, "/orders/123", nil)
+			w := httptest.NewRecorder()
+			e.ServeHTTP(w, req)
+			assert.Equal(t, http.StatusOK, w.Code)
+		}()
+	}
+	wg.Wait()
+
+	counts := loggedTypes(app)
+	assert.Equal(t, n, counts[logmanager.TxnTypeHttp], "one http entry per request")
+	assert.Equal(t, n, counts[logmanager.TxnTypeApi], "one api entry per request")
+	assert.Equal(t, n, counts[logmanager.TxnTypeDatabase], "one database entry per request")
+	assert.Equal(t, n, counts[logmanager.TxnTypeOther], "one other entry per request")
+}
+
+// TestEchoConcurrentFanoutWithinRequest is the key race probe: a single request
+// whose handler fans out to many goroutines that all mutate the SAME transaction
+// concurrently (parallel downstream calls). Targets the shared txnRecords map,
+// tags slice and attrs map. Run with -race.
+func TestEchoConcurrentFanoutWithinRequest(t *testing.T) {
+	const fanout = 50
+
+	app := logmanager.NewTestableApplication()
+	app.ResetLoggedEntries()
+
+	e := echo.New()
+	e.Use(lmecho.Middleware(app.Application))
+	e.GET("/fanout", func(c echo.Context) error {
+		tx := logmanager.FromContext(c.Request().Context())
+
+		var wg sync.WaitGroup
+		wg.Add(fanout)
+		for i := 0; i < fanout; i++ {
+			go func(i int) {
+				defer wg.Done()
+
+				db := tx.AddDatabase("db-call")
+				db.AddTags("db", "fanout")
+				db.SetResponseValue(map[string]any{"row": i})
+				db.End()
+
+				api := tx.AddTxn("api-call", logmanager.TxnTypeApi)
+				api.AddTags("api")
+				api.SetResponseValue(map[string]any{"ok": true})
+				api.End()
+			}(i)
+		}
+		wg.Wait()
+
+		return c.JSON(http.StatusOK, map[string]any{"message": "ok"})
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/fanout", nil)
+	w := httptest.NewRecorder()
+	e.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.GreaterOrEqual(t, loggedTypes(app)[logmanager.TxnTypeHttp], 1, "http entry must be logged")
+}

--- a/logmanager/integrations/lmgin/integration_test.go
+++ b/logmanager/integrations/lmgin/integration_test.go
@@ -1,0 +1,183 @@
+package lmgin_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/SALT-Indonesia/salt-pkg/logmanager"
+	"github.com/SALT-Indonesia/salt-pkg/logmanager/integrations/lmgin"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+// loggedTypes counts the captured log entries grouped by their "type" field.
+// Entries are produced both by the middleware (http) and by every nested
+// TxnRecord.End() call (api, database, other, ...).
+func loggedTypes(app *logmanager.TestableApplication) map[logmanager.TxnType]int {
+	counts := make(map[logmanager.TxnType]int)
+	for _, entry := range app.GetLoggedEntries() {
+		if v, ok := entry.Data["type"]; ok {
+			if t, ok := v.(logmanager.TxnType); ok {
+				counts[t]++
+			}
+		}
+	}
+	return counts
+}
+
+// fullProcessingHandler simulates a realistic REST handler that, while serving
+// one request, performs an outbound API call, a database query and some other
+// internal work — each of which must produce its own log entry. The surrounding
+// middleware produces the http entry on tx.End().
+func fullProcessingHandler(c *gin.Context) {
+	tx := logmanager.FromContext(c.Request.Context())
+
+	// api: outbound HTTP call
+	apiTxn := tx.AddTxn("call-payment-api", logmanager.TxnTypeApi)
+	apiTxn.SetRequestValue(map[string]any{"order_id": c.Param("id")})
+	apiTxn.SetResponseValue(map[string]any{"status": "charged"})
+	apiTxn.End()
+
+	// database: query
+	dbTxn := logmanager.StartDatabaseSegment(tx, logmanager.DatabaseSegment{
+		Name:  "select-orders",
+		Table: "orders",
+		Query: "SELECT * FROM orders WHERE id = ?",
+		Host:  "localhost",
+	})
+	dbTxn.End()
+
+	// other: internal computation
+	otherTxn := logmanager.StartOtherSegment(tx, logmanager.OtherSegment{
+		Name:  "compute-tax",
+		Extra: map[string]interface{}{"region": "ID"},
+	})
+	otherTxn.End()
+
+	c.JSON(http.StatusOK, gin.H{"message": "ok", "id": c.Param("id")})
+}
+
+func newRouter(app *logmanager.TestableApplication) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(lmgin.Middleware(app.Application))
+	r.GET("/orders/:id", fullProcessingHandler)
+	return r
+}
+
+// TestGinAllLogTypesPresent proves that a single REST request emits every
+// expected transaction log type: http, api, database and other.
+func TestGinAllLogTypesPresent(t *testing.T) {
+	app := logmanager.NewTestableApplication()
+	app.ResetLoggedEntries()
+	r := newRouter(app)
+
+	req := httptest.NewRequest(http.MethodGet, "/orders/123", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	counts := loggedTypes(app)
+	for _, want := range []logmanager.TxnType{
+		logmanager.TxnTypeHttp,
+		logmanager.TxnTypeApi,
+		logmanager.TxnTypeDatabase,
+		logmanager.TxnTypeOther,
+	} {
+		assert.GreaterOrEqual(t, counts[want], 1, "expected at least one %q log entry", want)
+	}
+
+	// Every entry produced during one request must share the same trace_id.
+	var traceID string
+	for _, entry := range app.GetLoggedEntries() {
+		got, _ := entry.Data["trace_id"].(string)
+		assert.NotEmpty(t, got, "trace_id should not be empty")
+		if traceID == "" {
+			traceID = got
+		} else {
+			assert.Equal(t, traceID, got, "all entries in a request should share trace_id")
+		}
+	}
+}
+
+// TestGinConcurrentRequests drives many requests concurrently against the same
+// app/router to emulate high production traffic. Run with -race to surface any
+// shared-state data races across requests.
+func TestGinConcurrentRequests(t *testing.T) {
+	const n = 200
+
+	app := logmanager.NewTestableApplication()
+	app.ResetLoggedEntries()
+	r := newRouter(app)
+
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			req := httptest.NewRequest(http.MethodGet, "/orders/123", nil)
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+			assert.Equal(t, http.StatusOK, w.Code)
+		}()
+	}
+	wg.Wait()
+
+	counts := loggedTypes(app)
+	assert.Equal(t, n, counts[logmanager.TxnTypeHttp], "one http entry per request")
+	assert.Equal(t, n, counts[logmanager.TxnTypeApi], "one api entry per request")
+	assert.Equal(t, n, counts[logmanager.TxnTypeDatabase], "one database entry per request")
+	assert.Equal(t, n, counts[logmanager.TxnTypeOther], "one other entry per request")
+}
+
+// TestGinConcurrentFanoutWithinRequest is the key race probe: a single request
+// whose handler fans out to many goroutines that all mutate the SAME transaction
+// concurrently (parallel downstream calls — a common production pattern). This
+// targets the shared txnRecords map, the tags slice and the attrs map. Run with
+// -race; a "concurrent map writes" panic or a reported data race confirms the
+// production risk.
+func TestGinConcurrentFanoutWithinRequest(t *testing.T) {
+	const fanout = 50
+
+	app := logmanager.NewTestableApplication()
+	app.ResetLoggedEntries()
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(lmgin.Middleware(app.Application))
+	r.GET("/fanout", func(c *gin.Context) {
+		tx := logmanager.FromContext(c.Request.Context())
+
+		var wg sync.WaitGroup
+		wg.Add(fanout)
+		for i := 0; i < fanout; i++ {
+			go func(i int) {
+				defer wg.Done()
+
+				db := tx.AddDatabase("db-call")
+				db.AddTags("db", "fanout")
+				db.SetResponseValue(map[string]any{"row": i})
+				db.End()
+
+				api := tx.AddTxn("api-call", logmanager.TxnTypeApi)
+				api.AddTags("api")
+				api.SetResponseValue(map[string]any{"ok": true})
+				api.End()
+			}(i)
+		}
+		wg.Wait()
+
+		c.JSON(http.StatusOK, gin.H{"message": "ok"})
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/fanout", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.GreaterOrEqual(t, loggedTypes(app)[logmanager.TxnTypeHttp], 1, "http entry must be logged")
+}

--- a/logmanager/integrations/lmgorilla/integration_test.go
+++ b/logmanager/integrations/lmgorilla/integration_test.go
@@ -1,0 +1,177 @@
+package lmgorilla_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/SALT-Indonesia/salt-pkg/logmanager"
+	"github.com/SALT-Indonesia/salt-pkg/logmanager/integrations/lmgorilla"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+)
+
+// loggedTypes counts the captured log entries grouped by their "type" field.
+// Entries are produced both by the middleware (http) and by every nested
+// TxnRecord.End() call (api, database, other, ...).
+func loggedTypes(app *logmanager.TestableApplication) map[logmanager.TxnType]int {
+	counts := make(map[logmanager.TxnType]int)
+	for _, entry := range app.GetLoggedEntries() {
+		if v, ok := entry.Data["type"]; ok {
+			if t, ok := v.(logmanager.TxnType); ok {
+				counts[t]++
+			}
+		}
+	}
+	return counts
+}
+
+// fullProcessingHandler simulates a realistic REST handler that, while serving
+// one request, performs an outbound API call, a database query and some other
+// internal work — each producing its own log entry. The middleware produces the
+// http entry on tx.End().
+func fullProcessingHandler(w http.ResponseWriter, r *http.Request) {
+	tx := logmanager.FromContext(r.Context())
+
+	apiTxn := tx.AddTxn("call-payment-api", logmanager.TxnTypeApi)
+	apiTxn.SetRequestValue(map[string]any{"order_id": mux.Vars(r)["id"]})
+	apiTxn.SetResponseValue(map[string]any{"status": "charged"})
+	apiTxn.End()
+
+	dbTxn := logmanager.StartDatabaseSegment(tx, logmanager.DatabaseSegment{
+		Name:  "select-orders",
+		Table: "orders",
+		Query: "SELECT * FROM orders WHERE id = ?",
+		Host:  "localhost",
+	})
+	dbTxn.End()
+
+	otherTxn := logmanager.StartOtherSegment(tx, logmanager.OtherSegment{
+		Name:  "compute-tax",
+		Extra: map[string]interface{}{"region": "ID"},
+	})
+	otherTxn.End()
+
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(`{"message":"ok"}`))
+}
+
+func newRouter(app *logmanager.TestableApplication) *mux.Router {
+	r := mux.NewRouter()
+	r.Use(lmgorilla.Middleware(app.Application))
+	r.HandleFunc("/orders/{id}", fullProcessingHandler).Methods(http.MethodGet)
+	return r
+}
+
+// TestGorillaAllLogTypesPresent proves that a single REST request emits every
+// expected transaction log type: http, api, database and other.
+func TestGorillaAllLogTypesPresent(t *testing.T) {
+	app := logmanager.NewTestableApplication()
+	app.ResetLoggedEntries()
+	r := newRouter(app)
+
+	req := httptest.NewRequest(http.MethodGet, "/orders/123", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	counts := loggedTypes(app)
+	for _, want := range []logmanager.TxnType{
+		logmanager.TxnTypeHttp,
+		logmanager.TxnTypeApi,
+		logmanager.TxnTypeDatabase,
+		logmanager.TxnTypeOther,
+	} {
+		assert.GreaterOrEqual(t, counts[want], 1, "expected at least one %q log entry", want)
+	}
+
+	var traceID string
+	for _, entry := range app.GetLoggedEntries() {
+		got, _ := entry.Data["trace_id"].(string)
+		assert.NotEmpty(t, got, "trace_id should not be empty")
+		if traceID == "" {
+			traceID = got
+		} else {
+			assert.Equal(t, traceID, got, "all entries in a request should share trace_id")
+		}
+	}
+}
+
+// TestGorillaConcurrentRequests drives many requests concurrently against the
+// same app/router to emulate high production traffic. Run with -race to surface
+// any shared-state data races across requests.
+func TestGorillaConcurrentRequests(t *testing.T) {
+	const n = 200
+
+	app := logmanager.NewTestableApplication()
+	app.ResetLoggedEntries()
+	r := newRouter(app)
+
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			req := httptest.NewRequest(http.MethodGet, "/orders/123", nil)
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+			assert.Equal(t, http.StatusOK, w.Code)
+		}()
+	}
+	wg.Wait()
+
+	counts := loggedTypes(app)
+	assert.Equal(t, n, counts[logmanager.TxnTypeHttp], "one http entry per request")
+	assert.Equal(t, n, counts[logmanager.TxnTypeApi], "one api entry per request")
+	assert.Equal(t, n, counts[logmanager.TxnTypeDatabase], "one database entry per request")
+	assert.Equal(t, n, counts[logmanager.TxnTypeOther], "one other entry per request")
+}
+
+// TestGorillaConcurrentFanoutWithinRequest is the key race probe: a single
+// request whose handler fans out to many goroutines that all mutate the SAME
+// transaction concurrently (parallel downstream calls). Targets the shared
+// txnRecords map, tags slice and attrs map. Run with -race.
+func TestGorillaConcurrentFanoutWithinRequest(t *testing.T) {
+	const fanout = 50
+
+	app := logmanager.NewTestableApplication()
+	app.ResetLoggedEntries()
+
+	r := mux.NewRouter()
+	r.Use(lmgorilla.Middleware(app.Application))
+	r.HandleFunc("/fanout", func(w http.ResponseWriter, req *http.Request) {
+		tx := logmanager.FromContext(req.Context())
+
+		var wg sync.WaitGroup
+		wg.Add(fanout)
+		for i := 0; i < fanout; i++ {
+			go func(i int) {
+				defer wg.Done()
+
+				db := tx.AddDatabase("db-call")
+				db.AddTags("db", "fanout")
+				db.SetResponseValue(map[string]any{"row": i})
+				db.End()
+
+				api := tx.AddTxn("api-call", logmanager.TxnTypeApi)
+				api.AddTags("api")
+				api.SetResponseValue(map[string]any{"ok": true})
+				api.End()
+			}(i)
+		}
+		wg.Wait()
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"message":"ok"}`))
+	}).Methods(http.MethodGet)
+
+	req := httptest.NewRequest(http.MethodGet, "/fanout", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.GreaterOrEqual(t, loggedTypes(app)[logmanager.TxnTypeHttp], 1, "http entry must be logged")
+}

--- a/logmanager/integrations/lmgrpc/integration_test.go
+++ b/logmanager/integrations/lmgrpc/integration_test.go
@@ -1,0 +1,171 @@
+package lmgrpc_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/SALT-Indonesia/salt-pkg/logmanager"
+	"github.com/SALT-Indonesia/salt-pkg/logmanager/integrations/lmgrpc"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+// loggedTypes counts the captured log entries grouped by their "type" field.
+func loggedTypes(app *logmanager.TestableApplication) map[logmanager.TxnType]int {
+	counts := make(map[logmanager.TxnType]int)
+	for _, entry := range app.GetLoggedEntries() {
+		if v, ok := entry.Data["type"]; ok {
+			if t, ok := v.(logmanager.TxnType); ok {
+				counts[t]++
+			}
+		}
+	}
+	return counts
+}
+
+// fullProcessingHandler simulates a gRPC handler that, while serving one RPC,
+// performs an outbound API call, a database query, some other internal work and
+// a downstream gRPC call — each producing its own log entry. The interceptor
+// produces the http entry on tx.End().
+func fullProcessingHandler(ctx context.Context, _ interface{}) (interface{}, error) {
+	tx := logmanager.FromContext(ctx)
+
+	// api: outbound HTTP call
+	apiTxn := tx.AddTxn("call-payment-api", logmanager.TxnTypeApi)
+	apiTxn.SetRequestValue(map[string]any{"order_id": "123"})
+	apiTxn.SetResponseValue(map[string]any{"status": "charged"})
+	apiTxn.End()
+
+	// database: query
+	dbTxn := logmanager.StartDatabaseSegment(tx, logmanager.DatabaseSegment{
+		Name:  "select-orders",
+		Table: "orders",
+		Query: "SELECT * FROM orders WHERE id = ?",
+		Host:  "localhost",
+	})
+	dbTxn.End()
+
+	// other: internal computation
+	otherTxn := logmanager.StartOtherSegment(tx, logmanager.OtherSegment{
+		Name:  "compute-tax",
+		Extra: map[string]interface{}{"region": "ID"},
+	})
+	otherTxn.End()
+
+	// grpc: downstream gRPC call
+	grpcTxn := logmanager.StartGrpcSegment(tx, logmanager.GrpcSegment{
+		Url:     "/payment.Service/Charge",
+		Request: map[string]any{"order_id": "123"},
+	})
+	grpcTxn.End()
+
+	return "mock-response", nil
+}
+
+func newServerCall(app *logmanager.TestableApplication, handler grpc.UnaryHandler) (interface{}, error) {
+	interceptor := lmgrpc.UnaryServerInterceptor(app.Application)
+	md := metadata.Pairs(app.TraceIDHeaderKey(), "trace-abc")
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+	return interceptor(ctx, "mock-request", &grpc.UnaryServerInfo{FullMethod: "/order.Service/Get"}, handler)
+}
+
+// TestGrpcAllLogTypesPresent proves that a single gRPC unary call emits every
+// expected transaction log type: http, api, database, other and grpc.
+func TestGrpcAllLogTypesPresent(t *testing.T) {
+	app := logmanager.NewTestableApplication()
+	app.ResetLoggedEntries()
+
+	resp, err := newServerCall(app, fullProcessingHandler)
+	assert.NoError(t, err)
+	assert.Equal(t, "mock-response", resp)
+
+	counts := loggedTypes(app)
+	for _, want := range []logmanager.TxnType{
+		logmanager.TxnTypeHttp,
+		logmanager.TxnTypeApi,
+		logmanager.TxnTypeDatabase,
+		logmanager.TxnTypeOther,
+		logmanager.TxnTypeGrpc,
+	} {
+		assert.GreaterOrEqual(t, counts[want], 1, "expected at least one %q log entry", want)
+	}
+
+	// Every entry produced during one RPC must share the same trace_id.
+	for _, entry := range app.GetLoggedEntries() {
+		assert.Equal(t, "trace-abc", entry.Data["trace_id"], "all entries should share trace_id")
+	}
+}
+
+// TestGrpcConcurrentCalls drives many unary calls concurrently against the same
+// app to emulate high production traffic. Run with -race to surface any
+// shared-state data races across calls.
+func TestGrpcConcurrentCalls(t *testing.T) {
+	const n = 200
+
+	app := logmanager.NewTestableApplication()
+	app.ResetLoggedEntries()
+
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			resp, err := newServerCall(app, fullProcessingHandler)
+			assert.NoError(t, err)
+			assert.Equal(t, "mock-response", resp)
+		}()
+	}
+	wg.Wait()
+
+	counts := loggedTypes(app)
+	assert.Equal(t, n, counts[logmanager.TxnTypeHttp], "one http entry per call")
+	assert.Equal(t, n, counts[logmanager.TxnTypeApi], "one api entry per call")
+	assert.Equal(t, n, counts[logmanager.TxnTypeDatabase], "one database entry per call")
+	assert.Equal(t, n, counts[logmanager.TxnTypeOther], "one other entry per call")
+	assert.Equal(t, n, counts[logmanager.TxnTypeGrpc], "one grpc entry per call")
+}
+
+// TestGrpcConcurrentFanoutWithinCall is the key race probe: a single RPC whose
+// handler fans out to many goroutines that all mutate the SAME transaction
+// concurrently. This targets the shared txnRecords map, the tags slice and the
+// attrs map. Run with -race; a "concurrent map writes" panic or a reported data
+// race confirms the production risk.
+func TestGrpcConcurrentFanoutWithinCall(t *testing.T) {
+	const fanout = 50
+
+	app := logmanager.NewTestableApplication()
+	app.ResetLoggedEntries()
+
+	handler := func(ctx context.Context, _ interface{}) (interface{}, error) {
+		tx := logmanager.FromContext(ctx)
+
+		var wg sync.WaitGroup
+		wg.Add(fanout)
+		for i := 0; i < fanout; i++ {
+			go func(i int) {
+				defer wg.Done()
+
+				db := tx.AddDatabase("db-call")
+				db.AddTags("db", "fanout")
+				db.SetResponseValue(map[string]any{"row": i})
+				db.End()
+
+				api := tx.AddTxn("api-call", logmanager.TxnTypeApi)
+				api.AddTags("api")
+				api.SetResponseValue(map[string]any{"ok": true})
+				api.End()
+			}(i)
+		}
+		wg.Wait()
+
+		return "mock-response", nil
+	}
+
+	resp, err := newServerCall(app, handler)
+	assert.NoError(t, err)
+	assert.Equal(t, "mock-response", resp)
+	assert.GreaterOrEqual(t, loggedTypes(app)[logmanager.TxnTypeHttp], 1, "http entry must be logged")
+}

--- a/logmanager/integrations/lmrabbitmq/integration_test.go
+++ b/logmanager/integrations/lmrabbitmq/integration_test.go
@@ -1,0 +1,152 @@
+package lmrabbitmq_test
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/SALT-Indonesia/salt-pkg/logmanager"
+	"github.com/SALT-Indonesia/salt-pkg/logmanager/integrations/lmrabbitmq"
+
+	"github.com/rabbitmq/amqp091-go"
+	"github.com/stretchr/testify/assert"
+)
+
+// loggedTypes counts the captured log entries grouped by their "type" field.
+// Entries are produced both by the consumer transaction (consumer) and by
+// every nested TxnRecord.End() call (api, database, other, ...).
+func loggedTypes(app *logmanager.TestableApplication) map[logmanager.TxnType]int {
+	counts := make(map[logmanager.TxnType]int)
+	for _, entry := range app.GetLoggedEntries() {
+		if v, ok := entry.Data["type"]; ok {
+			if t, ok := v.(logmanager.TxnType); ok {
+				counts[t]++
+			}
+		}
+	}
+	return counts
+}
+
+func newDelivery() amqp091.Delivery {
+	return amqp091.Delivery{
+		Exchange:   "orders-exchange",
+		RoutingKey: "orders.created",
+		Body:       []byte(`{"order_id":"123"}`),
+	}
+}
+
+// processMessage simulates a realistic RabbitMQ consumer that, while handling
+// one message, performs an outbound API call, a database query and some other
+// internal work — each producing its own log entry. The consumer transaction
+// produces the consumer entry on tx.End().
+func processMessage(app *logmanager.Application, traceID string) {
+	consumer := lmrabbitmq.NewConsumer("orders-queue", newDelivery())
+
+	tx := app.StartConsumer(traceID)
+	tx.SetConsumer(consumer)
+	defer tx.End()
+
+	apiTxn := tx.AddTxn("call-payment-api", logmanager.TxnTypeApi)
+	apiTxn.SetRequestValue(map[string]any{"order_id": "123"})
+	apiTxn.SetResponseValue(map[string]any{"status": "charged"})
+	apiTxn.End()
+
+	dbTxn := logmanager.StartDatabaseSegment(tx, logmanager.DatabaseSegment{
+		Name:  "insert-order",
+		Table: "orders",
+		Query: "INSERT INTO orders ...",
+		Host:  "localhost",
+	})
+	dbTxn.End()
+
+	otherTxn := logmanager.StartOtherSegment(tx, logmanager.OtherSegment{
+		Name:  "compute-tax",
+		Extra: map[string]interface{}{"region": "ID"},
+	})
+	otherTxn.End()
+}
+
+// TestRabbitMQAllLogTypesPresent proves that handling a single message emits
+// every expected transaction log type: consumer, api, database and other.
+func TestRabbitMQAllLogTypesPresent(t *testing.T) {
+	app := logmanager.NewTestableApplication()
+	app.ResetLoggedEntries()
+
+	processMessage(app.Application, "trace-abc")
+
+	counts := loggedTypes(app)
+	for _, want := range []logmanager.TxnType{
+		logmanager.TxnTypeConsumer,
+		logmanager.TxnTypeApi,
+		logmanager.TxnTypeDatabase,
+		logmanager.TxnTypeOther,
+	} {
+		assert.GreaterOrEqual(t, counts[want], 1, "expected at least one %q log entry", want)
+	}
+
+	for _, entry := range app.GetLoggedEntries() {
+		assert.Equal(t, "trace-abc", entry.Data["trace_id"], "all entries should share trace_id")
+	}
+}
+
+// TestRabbitMQConcurrentMessages handles many messages concurrently against the
+// same app to emulate high-throughput consumption. Run with -race to surface any
+// shared-state data races across messages.
+func TestRabbitMQConcurrentMessages(t *testing.T) {
+	const n = 200
+
+	app := logmanager.NewTestableApplication()
+	app.ResetLoggedEntries()
+
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			processMessage(app.Application, "trace-abc")
+		}()
+	}
+	wg.Wait()
+
+	counts := loggedTypes(app)
+	assert.Equal(t, n, counts[logmanager.TxnTypeConsumer], "one consumer entry per message")
+	assert.Equal(t, n, counts[logmanager.TxnTypeApi], "one api entry per message")
+	assert.Equal(t, n, counts[logmanager.TxnTypeDatabase], "one database entry per message")
+	assert.Equal(t, n, counts[logmanager.TxnTypeOther], "one other entry per message")
+}
+
+// TestRabbitMQConcurrentFanoutWithinMessage is the key race probe: a single
+// message whose handler fans out to many goroutines that all mutate the SAME
+// transaction concurrently. Targets the shared txnRecords map, tags slice and
+// attrs map. Run with -race.
+func TestRabbitMQConcurrentFanoutWithinMessage(t *testing.T) {
+	const fanout = 50
+
+	app := logmanager.NewTestableApplication()
+	app.ResetLoggedEntries()
+
+	consumer := lmrabbitmq.NewConsumer("orders-queue", newDelivery())
+	tx := app.StartConsumer("trace-abc")
+	tx.SetConsumer(consumer)
+
+	var wg sync.WaitGroup
+	wg.Add(fanout)
+	for i := 0; i < fanout; i++ {
+		go func(i int) {
+			defer wg.Done()
+
+			db := tx.AddDatabase("db-call")
+			db.AddTags("db", "fanout")
+			db.SetResponseValue(map[string]any{"row": i})
+			db.End()
+
+			api := tx.AddTxn("api-call", logmanager.TxnTypeApi)
+			api.AddTags("api")
+			api.SetResponseValue(map[string]any{"ok": true})
+			api.End()
+		}(i)
+	}
+	wg.Wait()
+	tx.End()
+
+	assert.GreaterOrEqual(t, loggedTypes(app)[logmanager.TxnTypeConsumer], 1, "consumer entry must be logged")
+}

--- a/logmanager/integrations/lmresty/integration_test.go
+++ b/logmanager/integrations/lmresty/integration_test.go
@@ -1,0 +1,172 @@
+package lmresty_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/SALT-Indonesia/salt-pkg/logmanager"
+	"github.com/SALT-Indonesia/salt-pkg/logmanager/integrations/lmresty"
+
+	"github.com/go-resty/resty/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+// loggedTypes counts the captured log entries grouped by their "type" field.
+// Entries are produced by the root transaction (http) and by every nested
+// TxnRecord.End() call, including the resty api segment.
+func loggedTypes(app *logmanager.TestableApplication) map[logmanager.TxnType]int {
+	counts := make(map[logmanager.TxnType]int)
+	for _, entry := range app.GetLoggedEntries() {
+		if v, ok := entry.Data["type"]; ok {
+			if t, ok := v.(logmanager.TxnType); ok {
+				counts[t]++
+			}
+		}
+	}
+	return counts
+}
+
+func newTestServer() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"message":"success"}`))
+	}))
+}
+
+// handleRequest simulates a realistic flow: a root transaction makes an outbound
+// HTTP call through resty (logged via lmresty.NewTxn as an api segment), plus a
+// database query and some other internal work. Every step produces a log entry;
+// the root transaction produces the http entry on tx.End().
+func handleRequest(app *logmanager.Application, client *resty.Client, traceID string) error {
+	tx := app.StartHttp(traceID, "GET /proxy")
+	defer tx.End()
+
+	ctx := tx.ToContext(context.Background())
+
+	resp, err := client.R().SetContext(ctx).Get("/downstream")
+	if err != nil {
+		return err
+	}
+	// api: the outbound resty call
+	apiTxn := lmresty.NewTxn(resp)
+	apiTxn.End()
+
+	dbTxn := logmanager.StartDatabaseSegment(tx, logmanager.DatabaseSegment{
+		Name:  "select-orders",
+		Table: "orders",
+		Query: "SELECT * FROM orders WHERE id = ?",
+		Host:  "localhost",
+	})
+	dbTxn.End()
+
+	otherTxn := logmanager.StartOtherSegment(tx, logmanager.OtherSegment{
+		Name:  "compute-tax",
+		Extra: map[string]interface{}{"region": "ID"},
+	})
+	otherTxn.End()
+
+	return nil
+}
+
+// TestRestyAllLogTypesPresent proves that a single request flow emits every
+// expected transaction log type: http, api (resty), database and other.
+func TestRestyAllLogTypesPresent(t *testing.T) {
+	server := newTestServer()
+	defer server.Close()
+
+	client := resty.New().SetBaseURL(server.URL)
+
+	app := logmanager.NewTestableApplication()
+	app.ResetLoggedEntries()
+
+	assert.NoError(t, handleRequest(app.Application, client, "trace-abc"))
+
+	counts := loggedTypes(app)
+	for _, want := range []logmanager.TxnType{
+		logmanager.TxnTypeHttp,
+		logmanager.TxnTypeApi,
+		logmanager.TxnTypeDatabase,
+		logmanager.TxnTypeOther,
+	} {
+		assert.GreaterOrEqual(t, counts[want], 1, "expected at least one %q log entry", want)
+	}
+
+	for _, entry := range app.GetLoggedEntries() {
+		assert.Equal(t, "trace-abc", entry.Data["trace_id"], "all entries should share trace_id")
+	}
+}
+
+// TestRestyConcurrentRequests drives many request flows concurrently against the
+// same app and resty client to emulate high production traffic. Run with -race
+// to surface any shared-state data races across requests.
+func TestRestyConcurrentRequests(t *testing.T) {
+	const n = 200
+
+	server := newTestServer()
+	defer server.Close()
+
+	client := resty.New().SetBaseURL(server.URL)
+
+	app := logmanager.NewTestableApplication()
+	app.ResetLoggedEntries()
+
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			assert.NoError(t, handleRequest(app.Application, client, "trace-abc"))
+		}()
+	}
+	wg.Wait()
+
+	counts := loggedTypes(app)
+	assert.Equal(t, n, counts[logmanager.TxnTypeHttp], "one http entry per request")
+	assert.Equal(t, n, counts[logmanager.TxnTypeApi], "one api entry per request")
+	assert.Equal(t, n, counts[logmanager.TxnTypeDatabase], "one database entry per request")
+	assert.Equal(t, n, counts[logmanager.TxnTypeOther], "one other entry per request")
+}
+
+// TestRestyConcurrentFanoutWithinRequest is the key race probe: a single request
+// whose handler fans out to many goroutines that each make a resty call and add
+// segments to the SAME transaction concurrently. Targets the shared txnRecords
+// map, tags slice and attrs map. Run with -race.
+func TestRestyConcurrentFanoutWithinRequest(t *testing.T) {
+	const fanout = 50
+
+	server := newTestServer()
+	defer server.Close()
+
+	client := resty.New().SetBaseURL(server.URL)
+
+	app := logmanager.NewTestableApplication()
+	app.ResetLoggedEntries()
+
+	tx := app.StartHttp("trace-abc", "GET /proxy")
+	ctx := tx.ToContext(context.Background())
+
+	var wg sync.WaitGroup
+	wg.Add(fanout)
+	for i := 0; i < fanout; i++ {
+		go func(i int) {
+			defer wg.Done()
+
+			resp, err := client.R().SetContext(ctx).Get("/downstream")
+			assert.NoError(t, err)
+			apiTxn := lmresty.NewTxn(resp)
+			apiTxn.AddTags("api", "fanout")
+			apiTxn.End()
+
+			db := tx.AddDatabase("db-call")
+			db.SetResponseValue(map[string]any{"row": i})
+			db.End()
+		}(i)
+	}
+	wg.Wait()
+	tx.End()
+
+	assert.GreaterOrEqual(t, loggedTypes(app)[logmanager.TxnTypeHttp], 1, "http entry must be logged")
+}

--- a/logmanager/transaction.go
+++ b/logmanager/transaction.go
@@ -101,9 +101,11 @@ func (t *Transaction) AddDatabase(name string) *TxnRecord {
 		return nil
 	}
 
-	s := t.AddTxn(name, TxnTypeDatabase)
-	t.txnRecords[name] = s
-	return s
+	// AddTxn (via AddTxnNow) already stores the record in txnRecords under
+	// the mutex. Writing it again here without the lock caused a data race
+	// (and a "concurrent map writes" panic) when handlers fan out across
+	// goroutines, so we rely on the synchronized write inside AddTxnNow.
+	return t.AddTxn(name, TxnTypeDatabase)
 }
 
 func (t *Transaction) TraceID() string {


### PR DESCRIPTION
## Context

We wanted to confirm whether `logmanager` survives high-traffic production scenarios. The approach: write high-traffic integration tests first, then run under `-race` to see what breaks.

It broke — and this PR both demonstrates the issue and fixes it.

## What's included

### 1. High-traffic integration tests (all six integrations)
New `integration_test.go` in `lmgin`, `lmgrpc`, `lmecho`, `lmgorilla`, `lmrabbitmq` and `lmresty`. Each verifies that a single unit of work emits **every** transaction log type and shares one `trace_id`, then probes concurrency under load with `-race`:

- **lmgin / lmecho / lmgorilla** — one REST request emits `http`, `api`, `database`, `other`.
- **lmgrpc** — one unary RPC emits `http`, `api`, `database`, `other`, `grpc`.
- **lmrabbitmq** — handling one message emits `consumer`, `api`, `database`, `other`.
- **lmresty** — one request flow makes an outbound resty call (`api`) under an `http` root plus `database` and `other` segments, against a real `httptest` server.

Each package has three tests:
- **AllLogTypesPresent** — asserts every expected log type is emitted with a shared `trace_id`.
- **ConcurrentRequests / Messages** (200 concurrent, `-race`) — independent units of work, each its own transaction. Safe.
- **FanoutWithinRequest / Message** (`-race`) — a single handler fans out to 50 goroutines that mutate the **same** transaction (parallel downstream calls — a common production pattern).

### 2. The fix
The fanout tests reproduced a data race + `concurrent map writes` panic on `Transaction.txnRecords`. Root cause: `AddDatabase` wrote the map a second time **outside** the mutex, even though `AddTxnNow` already stores it under the lock. Removed the redundant unlocked write so all map mutations are synchronized.

The defect was framework-independent — it lives in the core `Transaction` type, which is why all integrations reproduced it identically.

## Verification

```
go test ./logmanager/... -race -count=1   # all green
```

All fanout probes (previously panicking) now pass under `-race`, with no regressions across the module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)