### PR TITLE
feat: [logmanager] wildcard prefix support in WithExposeHeaders

### DIFF
--- a/examples/logmanager/08-expose-header-prefixes/README.md
+++ b/examples/logmanager/08-expose-header-prefixes/README.md
@@ -1,0 +1,64 @@
+# Expose Header Prefixes Example
+
+Selectively log infrastructure headers by **wildcard prefix** — even in production
+where `debug=false`.
+
+Teams behind Cloudflare / CloudFront usually want only a handful of infrastructure
+headers (`CF-Connecting-IP`, `CF-Ray`, `X-Amz-Cf-Id`, `X-Amzn-Trace-Id`, …) in their
+logs, without enumerating each one by exact name. `WithExposeHeaders` accepts a
+trailing-`*` wildcard so a single entry like `"CF-*"` exposes every header sharing
+that prefix.
+
+## Features
+
+- Wildcard/prefix header exposure via `WithExposeHeaders("CF-*", ...)`
+- Works in **production mode** (`WithEnvironment("production")`, `debug=false`)
+- Case-insensitive matching (Go canonicalizes `CF-Connecting-IP` → `Cf-Connecting-Ip`)
+- Non-matching headers (e.g. `User-Agent`) are dropped from logs
+
+## Key Concept
+
+```go
+app := logmanager.NewApplication(
+    logmanager.WithAppName("expose-header-prefixes-example"),
+    logmanager.WithEnvironment("production"), // debug=false, no WithDebug()
+    logmanager.WithExposeHeaders("CF-*", "X-Amz-Cf-*", "X-Amzn-*", "X-Request-Id"),
+)
+```
+
+Entries without `*` keep exact-match behavior; entries ending in `*` match by
+prefix. A bare `"*"` exposes all headers (equivalent to debug mode for headers).
+
+## Running
+
+```bash
+cd 08-expose-header-prefixes && go run main.go   # Port 8008
+```
+
+Then send a request with a mix of matching and non-matching headers:
+
+```bash
+curl http://localhost:8008/ping \
+  -H "CF-Ray: 8abc" \
+  -H "CF-Connecting-IP: 1.2.3.4" \
+  -H "X-Amzn-Trace-Id: Root=1-xyz" \
+  -H "X-Amz-Cf-Id: zzz" \
+  -H "User-Agent: noise"
+```
+
+## Expected Result
+
+The logged `headers` object contains only the prefix-matched headers — `User-Agent`
+is omitted — even though `debug` is `false`:
+
+```json
+{
+  "headers": {
+    "Cf-Ray": "8abc",
+    "Cf-Connecting-Ip": "1.2.3.4",
+    "X-Amzn-Trace-Id": "Root=1-xyz",
+    "X-Amz-Cf-Id": "zzz"
+  },
+  "type": "http"
+}
+```

--- a/examples/logmanager/08-expose-header-prefixes/main.go
+++ b/examples/logmanager/08-expose-header-prefixes/main.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/SALT-Indonesia/salt-pkg/logmanager"
+	"github.com/SALT-Indonesia/salt-pkg/logmanager/integrations/lmgin"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+const traceIDKey = "xid"
+
+func main() {
+	gin.SetMode(gin.ReleaseMode)
+
+	r := gin.New()
+
+	// Production mode: WithEnvironment("production") forces debug=false (no
+	// WithDebug()). Even so, the headers matched by the WithExposeHeaders
+	// wildcards below are still logged - infrastructure headers from Cloudflare
+	// (CF-*) and CloudFront (X-Amz-Cf-*, X-Amzn-*) survive, everything else is
+	// dropped. Wildcard matching is case-insensitive, so "CF-*" matches the
+	// canonicalized "Cf-Ray" Go produces.
+	app := logmanager.NewApplication(
+		logmanager.WithAppName("expose-header-prefixes-example"),
+		logmanager.WithEnvironment("production"),
+		logmanager.WithExposeHeaders("CF-*", "X-Amz-Cf-*", "X-Amzn-*", "X-Request-Id"),
+	)
+
+	r.Use(traceIDMiddleware(), lmgin.Middleware(app))
+
+	r.GET("/ping", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"message": "pong"})
+	})
+
+	fmt.Println("Server running at http://localhost:8008 (production mode, debug=false)")
+	fmt.Println("Try:")
+	fmt.Println(`  curl http://localhost:8008/ping \`)
+	fmt.Println(`    -H "CF-Ray: 8abc" \`)
+	fmt.Println(`    -H "CF-Connecting-IP: 1.2.3.4" \`)
+	fmt.Println(`    -H "X-Amzn-Trace-Id: Root=1-xyz" \`)
+	fmt.Println(`    -H "X-Amz-Cf-Id: zzz" \`)
+	fmt.Println(`    -H "User-Agent: noise"`)
+	fmt.Println("Notice: only the CF-*, X-Amz-Cf-*, X-Amzn-* (and X-Request-Id) headers")
+	fmt.Println("appear in the logged \"headers\" object - User-Agent is dropped - even though debug is off.")
+
+	if err := r.Run(":8008"); err != nil {
+		panic(err)
+	}
+}
+
+func traceIDMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Set(traceIDKey, uuid.NewString())
+		c.Next()
+	}
+}

--- a/examples/logmanager/README.md
+++ b/examples/logmanager/README.md
@@ -21,6 +21,8 @@ examples/logmanager/
 │   ├── content-types/    # Content type variations
 │   ├── query-headers/    # Query params & headers
 │   └── advanced/         # File uploads, streaming
+├── 07-skip-headers/      # Disable request header logging
+├── 08-expose-header-prefixes/ # Expose headers by wildcard prefix (CF-*, X-Amz-Cf-*)
 └── shared/               # Shared utilities
     ├── models/           # Common data models
     └── config/           # Configuration helpers
@@ -58,6 +60,10 @@ cd 06-http-methods/methods && go run main.go       # :8080
 cd 06-http-methods/content-types && go run main.go # :8081
 cd 06-http-methods/query-headers && go run main.go # :8082
 cd 06-http-methods/advanced && go run main.go      # :8083
+
+# Header logging controls
+cd 07-skip-headers && go run main.go               # :8007
+cd 08-expose-header-prefixes && go run main.go     # :8008
 ```
 
 ## 📚 Examples Overview
@@ -76,6 +82,8 @@ cd 06-http-methods/advanced && go run main.go      # :8083
 | **Content Types** | `06-http-methods/content-types/` | All content type variations |
 | **Query & Headers** | `06-http-methods/query-headers/` | Parameters and headers |
 | **Advanced HTTP** | `06-http-methods/advanced/` | File uploads, streaming |
+| **Skip Headers** | `07-skip-headers/` | Disable request header logging |
+| **Expose Header Prefixes** | `08-expose-header-prefixes/` | Wildcard header exposure (`CF-*`) in production |
 
 ## 🔧 Features Demonstrated
 

--- a/logmanager/CHANGELOG.md
+++ b/logmanager/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [1.44.0] - 2026-06-30
+- **Add wildcard/prefix support to `WithExposeHeaders` (e.g. `CF-*`)**
+  - An entry ending in `*` is now treated as a prefix, so a single config value like `"CF-*"` exposes every header sharing that prefix (e.g. `CF-Ray`, `CF-Connecting-IP`) instead of enumerating each header by exact name
+  - Prefix matching is case-insensitive, handling Go's header canonicalization (`CF-Connecting-IP` → `Cf-Connecting-Ip`); a bare `"*"` exposes all headers
+  - Exact (non-`*`) entries keep their existing behavior — fully backward-compatible
+  - Works in production (`debug=false`) and flows to both inbound HTTP logs and outbound resty/API logs via the existing `exposeHeaders` propagation; only `internal.Header.FilterHeaders()` changed
+  - Add `08-expose-header-prefixes` example: a Gin server in production mode logging Cloudflare/CloudFront headers by prefix
+  - Add unit tests for wildcard matching (case-insensitivity, mixed exact + wildcard, debug mode, bare `*`, no-match)
+
 ## [1.43.1] - 2026-06-18
 - **Fix data race / `concurrent map writes` panic on `Transaction.txnRecords` under concurrent fanout (#70)**
   - `AddDatabase` wrote `txnRecords[name]` a second time outside the mutex, even though `AddTxnNow` already stores it under the lock

--- a/logmanager/README.md
+++ b/logmanager/README.md
@@ -38,7 +38,7 @@ LogManager is a comprehensive structured logging library for Go applications tha
 | time        | timestamp | Log timestamp in RFC3339 format (e.g., `2023-07-14T11:20:22+07:00`)                                                                             |
 | stack_trace | string    | Error stack trace with file and line information                                                                                                |
 | tags        | array     | Custom tags for categorization (e.g., `["order", "payment"]`)                                                                                   |
-| headers     | object    | HTTP headers (exposed selectively via `WithExposeHeaders` configuration)                                                                        |
+| headers     | object    | HTTP headers (exposed selectively via `WithExposeHeaders`, by exact name or `CF-*` wildcard prefix)                                             |
 
 ## Quick Start
 
@@ -421,13 +421,36 @@ app := logmanager.NewApplication(
 
 ### Header Exposure
 
-Selectively expose HTTP headers in logs:
+Selectively expose HTTP headers in logs. This works even in production
+(`debug=false`) — only the configured headers are logged:
 
 ```go
 app := logmanager.NewApplication(
-    logmanager.WithExposeHeaders("X-User-Id"), // Enable header exposure
+    logmanager.WithExposeHeaders("X-User-Id"), // Exact header name
 )
+```
 
+#### Wildcard (prefix) exposure
+
+An entry ending in `*` is treated as a prefix, so you can expose a whole family
+of infrastructure headers without listing each one. Matching is
+case-insensitive (Go canonicalizes `CF-Connecting-IP` → `Cf-Connecting-Ip`):
+
+```go
+app := logmanager.NewApplication(
+    logmanager.WithExposeHeaders(
+        "CF-*",        // all Cloudflare headers: CF-Ray, CF-Connecting-IP, ...
+        "X-Amz-Cf-*",  // CloudFront: X-Amz-Cf-Id, ...
+        "X-Amzn-*",    // X-Amzn-Trace-Id, ...
+        "X-Request-Id",// exact names still work alongside wildcards
+    ),
+)
+```
+
+A bare `"*"` exposes all headers. See
+`examples/logmanager/08-expose-header-prefixes`.
+
+```go
 // Or expose all headers for specific endpoints
 func handler(c *gin.Context) {
     transaction := logmanager.FromContext(c.Request.Context())

--- a/logmanager/docs/ARCHITECTURE.md
+++ b/logmanager/docs/ARCHITECTURE.md
@@ -49,7 +49,7 @@ type Application struct {
     contextKey      string              // Key for storing in context
     maskingConfigs  []MaskingConfig     // Field masking rules
     tags            map[string]string   // Custom tags
-    exposeHeaders   bool                // Header exposure control
+    exposeHeaders   bool                // Header exposure control (supports "CF-*" wildcard prefixes)
 }
 ```
 

--- a/logmanager/internal/header.go
+++ b/logmanager/internal/header.go
@@ -1,5 +1,7 @@
 package internal
 
+import "strings"
+
 type Header struct {
 	Data           map[string]string
 	AllowedHeaders []string
@@ -30,9 +32,22 @@ func (h Header) FilterHeaders() map[string]string {
 		return h.Data
 	}
 
-	// Otherwise, filter only exposed headers
+	// Otherwise, filter only exposed headers. An entry may be either an exact
+	// header name or a trailing-"*" wildcard prefix (e.g. "CF-*" exposes every
+	// Cloudflare header). Wildcard matching is case-insensitive because Go
+	// canonicalizes header keys (e.g. "CF-Connecting-IP" -> "Cf-Connecting-Ip").
+	// A bare "*" therefore exposes all headers.
 	result := make(map[string]string)
 	for _, exposed := range h.AllowedHeaders {
+		if prefix, ok := strings.CutSuffix(exposed, "*"); ok {
+			lowerPrefix := strings.ToLower(prefix)
+			for key, value := range h.Data {
+				if strings.HasPrefix(strings.ToLower(key), lowerPrefix) {
+					result[key] = value
+				}
+			}
+			continue
+		}
 		if value, ok := h.Data[exposed]; ok {
 			result[exposed] = value
 		}

--- a/logmanager/internal/header_test.go
+++ b/logmanager/internal/header_test.go
@@ -85,6 +85,63 @@ func TestExtractHeader(t *testing.T) {
 			},
 			expectedResult: map[string]string{},
 		},
+		{
+			name: "wildcard prefix matches canonicalized headers case-insensitively",
+			header: internal.Header{
+				// Go canonicalizes "CF-Connecting-IP" -> "Cf-Connecting-Ip", etc.
+				Data:           map[string]string{"Cf-Ray": "8abc", "Cf-Connecting-Ip": "1.2.3.4", "User-Agent": "Go-http-client"},
+				AllowedHeaders: []string{"CF-*"},
+				IsDebugMode:    false,
+			},
+			expectedResult: map[string]string{"Cf-Ray": "8abc", "Cf-Connecting-Ip": "1.2.3.4"},
+		},
+		{
+			name: "mixed exact and wildcard exposed headers",
+			header: internal.Header{
+				Data: map[string]string{
+					"Cf-Ray":          "8abc",
+					"X-Amzn-Trace-Id": "Root=1-xyz",
+					"X-Amz-Cf-Id":     "zzz",
+					"Content-Type":    "application/json",
+					"User-Agent":      "Go-http-client",
+				},
+				AllowedHeaders: []string{"CF-*", "X-Amzn-*", "X-Amz-Cf-*", "Content-Type"},
+				IsDebugMode:    false,
+			},
+			expectedResult: map[string]string{
+				"Cf-Ray":          "8abc",
+				"X-Amzn-Trace-Id": "Root=1-xyz",
+				"X-Amz-Cf-Id":     "zzz",
+				"Content-Type":    "application/json",
+			},
+		},
+		{
+			name: "wildcard returns all headers in debug mode",
+			header: internal.Header{
+				Data:           map[string]string{"Cf-Ray": "8abc", "User-Agent": "Go-http-client"},
+				AllowedHeaders: []string{"CF-*"},
+				IsDebugMode:    true,
+			},
+			expectedResult: map[string]string{"Cf-Ray": "8abc", "User-Agent": "Go-http-client"},
+		},
+		{
+			name: "bare star wildcard exposes everything",
+			header: internal.Header{
+				Data:           map[string]string{"Cf-Ray": "8abc", "User-Agent": "Go-http-client"},
+				AllowedHeaders: []string{"*"},
+				IsDebugMode:    false,
+			},
+			expectedResult: map[string]string{"Cf-Ray": "8abc", "User-Agent": "Go-http-client"},
+		},
+		{
+			name: "wildcard with no matching headers yields empty map",
+			header: internal.Header{
+				Data:           map[string]string{"User-Agent": "Go-http-client", "Host": "example.com"},
+				AllowedHeaders: []string{"CF-*"},
+				IsDebugMode:    false,
+			},
+			expectedResult: map[string]string{},
+		},
 	}
 
 	for _, tt := range tests {

--- a/logmanager/option_test.go
+++ b/logmanager/option_test.go
@@ -109,6 +109,11 @@ func TestWithExposeHeaders(t *testing.T) {
 			[]string{"Content-Type", "Authorization", "User-Agent"},
 		},
 		{
+			"WildcardPrefixHeaders",
+			[]string{"CF-*", "X-Amz-Cf-*", "X-Amzn-*"},
+			[]string{"CF-*", "X-Amz-Cf-*", "X-Amzn-*"},
+		},
+		{
 			"NilHeaders",
 			nil,
 			nil,

--- a/skills/logmanager/SKILL.md
+++ b/skills/logmanager/SKILL.md
@@ -42,7 +42,9 @@ app := logmanager.NewApplication(
 
 Common options: `WithService`, `WithAppName`, `WithEnvironment`, `WithDebug`,
 `WithLogDir`, `WithSplitLevelOutput`, `WithTags`, `WithMaskingConfig`,
-`WithExposeHeaders`, `WithSkipHeaders`, `WithTraceIDKey` / `WithTraceIDHeaderKey`
+`WithExposeHeaders` (accepts exact names or trailing-`*` wildcard prefixes such
+as `"CF-*"`, matched case-insensitively), `WithSkipHeaders`, `WithTraceIDKey` /
+`WithTraceIDHeaderKey`
 / `WithTraceIDContextKey`, and `WithOpenTelemetry(WithOTelEndpoint(...), ...)`.
 
 ## Wire up middleware


### PR DESCRIPTION
## Summary

Adds **wildcard/prefix** support to `logmanager.WithExposeHeaders(...)`. An entry ending in `*` is treated as a prefix, so a single config value like `"CF-*"` exposes every header sharing that prefix — instead of enumerating each header by its exact canonical name.

Motivated by teams behind Cloudflare / CloudFront who want only their infrastructure headers (`CF-Connecting-IP`, `CF-Ray`, `X-Amz-Cf-Id`, `X-Amzn-Trace-Id`, …) in logs, **including in production where `debug=false`**.

```go
logmanager.NewApplication(
    logmanager.WithEnvironment("production"),               // debug=false
    logmanager.WithExposeHeaders("CF-*", "X-Amz-Cf-*", "X-Amzn-*", "X-Request-Id"),
)
```

## Details

- **Core change is tiny:** only `internal.Header.FilterHeaders()` changed. `exposeHeaders` already propagates app → root txn → child resty/API txn → header filter, so wildcard support automatically applies to both inbound HTTP logs and outbound resty logs.
- Prefix matching is **case-insensitive** to handle Go's header canonicalization (`CF-Connecting-IP` → `Cf-Connecting-Ip`). A bare `"*"` exposes all headers.
- Exact (non-`*`) entries keep their existing behavior — **fully backward-compatible**.

## Example

New `examples/logmanager/08-expose-header-prefixes` — a Gin server in production mode. Verified end-to-end: with `debug=false`, a request carrying `CF-Ray`, `CF-Connecting-IP`, `X-Amzn-Trace-Id`, `X-Amz-Cf-Id`, `User-Agent` logs only the prefix-matched headers; `User-Agent` is dropped.

## Tests & docs

- Unit tests in `header_test.go` (case-insensitivity, mixed exact + wildcard, debug mode, bare `*`, no-match) and a wildcard case in `option_test.go`.
- Updated `logmanager/README.md`, `logmanager/CHANGELOG.md` (`1.44.0`), `skills/logmanager/SKILL.md`, `logmanager/docs/ARCHITECTURE.md`, and `examples/logmanager/README.md`.

## Verification

- `go test ./logmanager/...` — all pass
- `go build ./examples/...` — ok
- `go vet ./logmanager/...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)