### PR TITLE
chore: bump logmanager to v1.44.0 across modules

### DIFF
--- a/clientmanager/go.mod
+++ b/clientmanager/go.mod
@@ -4,7 +4,7 @@ go 1.24.0
 
 require (
 	github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358
-	github.com/SALT-Indonesia/salt-pkg/logmanager v1.43.1
+	github.com/SALT-Indonesia/salt-pkg/logmanager v1.44.0
 	github.com/aws/aws-sdk-go-v2 v1.38.2
 	github.com/aws/aws-sdk-go-v2/credentials v1.18.8
 	github.com/dghubble/oauth1 v0.7.3

--- a/clientmanager/go.sum
+++ b/clientmanager/go.sum
@@ -2,6 +2,8 @@ github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358 h1:mFRzDkZVAjdal+
 github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358/go.mod h1:chxPXzSsl7ZWRAuOIE23GDNzjWuZquvFlgA8xmpunjU=
 github.com/SALT-Indonesia/salt-pkg/logmanager v1.43.1 h1:r6tC5g3J2G62INK3vnFSJ0FZ8XbyTcaZOcA3tB9QmUk=
 github.com/SALT-Indonesia/salt-pkg/logmanager v1.43.1/go.mod h1:Y/MycoisUMyxYtI8+wyHS62h5ga6LgvdrOXCIZ7BrSA=
+github.com/SALT-Indonesia/salt-pkg/logmanager v1.44.0 h1:cUjNhpv/9wMEsTM91NdzLm+Z+xunN1I0ppgdOWSbp58=
+github.com/SALT-Indonesia/salt-pkg/logmanager v1.44.0/go.mod h1:Y/MycoisUMyxYtI8+wyHS62h5ga6LgvdrOXCIZ7BrSA=
 github.com/aws/aws-sdk-go-v2 v1.38.2 h1:QUkLO1aTW0yqW95pVzZS0LGFanL71hJ0a49w4TJLMyM=
 github.com/aws/aws-sdk-go-v2 v1.38.2/go.mod h1:sDioUELIUO9Znk23YVmIk86/9DOpkbyyVb1i/gUNFXY=
 github.com/aws/aws-sdk-go-v2/credentials v1.18.8 h1:0FfdP0I9gs/f1rwtEdkcEdsclTEkPB8o6zWUG2Z8+IM=

--- a/eventmanager/go.mod
+++ b/eventmanager/go.mod
@@ -3,7 +3,7 @@ module github.com/SALT-Indonesia/salt-pkg/eventmanager
 go 1.24.0
 
 require (
-	github.com/SALT-Indonesia/salt-pkg/logmanager v1.43.1
+	github.com/SALT-Indonesia/salt-pkg/logmanager v1.44.0
 	github.com/go-playground/validator/v10 v10.27.0
 	github.com/google/uuid v1.6.0
 	github.com/joho/godotenv v1.5.1

--- a/eventmanager/go.sum
+++ b/eventmanager/go.sum
@@ -1,5 +1,7 @@
 github.com/SALT-Indonesia/salt-pkg/logmanager v1.43.1 h1:r6tC5g3J2G62INK3vnFSJ0FZ8XbyTcaZOcA3tB9QmUk=
 github.com/SALT-Indonesia/salt-pkg/logmanager v1.43.1/go.mod h1:Y/MycoisUMyxYtI8+wyHS62h5ga6LgvdrOXCIZ7BrSA=
+github.com/SALT-Indonesia/salt-pkg/logmanager v1.44.0 h1:cUjNhpv/9wMEsTM91NdzLm+Z+xunN1I0ppgdOWSbp58=
+github.com/SALT-Indonesia/salt-pkg/logmanager v1.44.0/go.mod h1:Y/MycoisUMyxYtI8+wyHS62h5ga6LgvdrOXCIZ7BrSA=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/IBM/sarama v1.46.0
 	github.com/SALT-Indonesia/salt-pkg/clientmanager v0.0.0
 	github.com/SALT-Indonesia/salt-pkg/httpmanager v0.12.0
-	github.com/SALT-Indonesia/salt-pkg/logmanager v1.43.1
+	github.com/SALT-Indonesia/salt-pkg/logmanager v1.44.0
 	github.com/gin-gonic/gin v1.10.1
 	github.com/go-resty/resty/v2 v2.16.5
 	github.com/golang-jwt/jwt/v5 v5.3.0

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -5,6 +5,8 @@ github.com/IBM/sarama v1.46.0/go.mod h1:0lOcuQziJ1/mBGHkdp5uYrltqQuKQKM5O5FOWUQV
 github.com/SALT-Indonesia/salt-pkg/httpmanager v0.12.0 h1:zMsCWh3rekEdDCHedUtJo3xu+q0noLsR5wl4FutEuQo=
 github.com/SALT-Indonesia/salt-pkg/httpmanager v0.12.0/go.mod h1:Cf+DSdNJZSN+qHgpPca0FexqMLIua1+luXZ2oPVVVSU=
 github.com/SALT-Indonesia/salt-pkg/logmanager v1.43.1 h1:r6tC5g3J2G62INK3vnFSJ0FZ8XbyTcaZOcA3tB9QmUk=
+github.com/SALT-Indonesia/salt-pkg/logmanager v1.44.0 h1:cUjNhpv/9wMEsTM91NdzLm+Z+xunN1I0ppgdOWSbp58=
+github.com/SALT-Indonesia/salt-pkg/logmanager v1.44.0/go.mod h1:Y/MycoisUMyxYtI8+wyHS62h5ga6LgvdrOXCIZ7BrSA=
 github.com/aws/aws-sdk-go-v2 v1.38.2 h1:QUkLO1aTW0yqW95pVzZS0LGFanL71hJ0a49w4TJLMyM=
 github.com/aws/aws-sdk-go-v2 v1.38.2/go.mod h1:sDioUELIUO9Znk23YVmIk86/9DOpkbyyVb1i/gUNFXY=
 github.com/aws/aws-sdk-go-v2/credentials v1.18.8 h1:0FfdP0I9gs/f1rwtEdkcEdsclTEkPB8o6zWUG2Z8+IM=
@@ -16,6 +18,7 @@ github.com/bytedance/sonic v1.14.0/go.mod h1:WoEbx8WTcFJfzCe0hbmyTGrfjt8PzNEBdxl
 github.com/bytedance/sonic/loader v0.3.0 h1:dskwH8edlzNMctoruo8FPTJDF3vLtDT0sXZwvZJyqeA=
 github.com/bytedance/sonic/loader v0.3.0/go.mod h1:N8A3vUdtUebEY2/VQC0MyhYeKUFosQU6FxH2JmUe6VI=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
+github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
@@ -46,6 +49,7 @@ github.com/gin-contrib/sse v1.1.0 h1:n0w2GMuUpWDVp7qSpvze6fAu9iRxJY4Hmj6AmBOU05w
 github.com/gin-contrib/sse v1.1.0/go.mod h1:hxRZ5gVpWMT7Z0B0gSNYqqsSCNIJMjzvm6fqCz9vjwM=
 github.com/gin-gonic/gin v1.10.1 h1:T0ujvqyCSqRopADpgPgiTT63DUQVSfojyME59Ei63pQ=
 github.com/gin-gonic/gin v1.10.1/go.mod h1:4PMNQiOhvDRa013RKVbsiNwoyezlm2rm0uX/T7kzp5Y=
+github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
@@ -80,6 +84,7 @@ github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWS
 github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
 github.com/gorilla/sessions v1.2.1/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/zI+bUmuGM=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.7 h1:X+2YciYSxvMQK0UZ7sg45ZVabVZBeBuvMkmuI2V3Fak=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.7/go.mod h1:lW34nIZuQ8UDPdkon5fmfp2l3+ZkQ2me/+oecHYLOII=
 github.com/hashicorp/go-uuid v1.0.2/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
@@ -182,7 +187,9 @@ go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbE
 go.opentelemetry.io/otel v1.40.0 h1:oA5YeOcpRTXq6NN7frwmwFR0Cn3RhTVZvXsP4duvCms=
 go.opentelemetry.io/otel v1.40.0/go.mod h1:IMb+uXZUKkMXdPddhwAHm6UfOwJyh4ct1ybIlV14J0g=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.40.0 h1:QKdN8ly8zEMrByybbQgv8cWBcdAarwmIPZ6FThrWXJs=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.40.0/go.mod h1:bTdK1nhqF76qiPoCCdyFIV+N/sRHYXYCTQc+3VCi3MI=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.40.0 h1:DvJDOPmSWQHWywQS6lKL+pb8s3gBLOZUtw4N+mavW1I=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.40.0/go.mod h1:EtekO9DEJb4/jRyN4v4Qjc2yA7AtfCBuz2FynRUWTXs=
 go.opentelemetry.io/otel/metric v1.40.0 h1:rcZe317KPftE2rstWIBitCdVp89A2HqjkxR3c11+p9g=
 go.opentelemetry.io/otel/metric v1.40.0/go.mod h1:ib/crwQH7N3r5kfiBZQbwrTge743UDc7DTFVZrrXnqc=
 go.opentelemetry.io/otel/sdk v1.40.0 h1:KHW/jUzgo6wsPh9At46+h4upjtccTmuZCFAc9OJ71f8=
@@ -192,6 +199,7 @@ go.opentelemetry.io/otel/sdk/metric v1.40.0/go.mod h1:4Z2bGMf0KSK3uRjlczMOeMhKU2
 go.opentelemetry.io/otel/trace v1.40.0 h1:WA4etStDttCSYuhwvEa8OP8I5EWu24lkOzp+ZYblVjw=
 go.opentelemetry.io/otel/trace v1.40.0/go.mod h1:zeAhriXecNGP/s2SEG3+Y8X9ujcJOTqQ5RgdEJcawiA=
 go.opentelemetry.io/proto/otlp v1.9.0 h1:l706jCMITVouPOqEnii2fIAuO3IVGBRPV5ICjceRb/A=
+go.opentelemetry.io/proto/otlp v1.9.0/go.mod h1:xE+Cx5E/eEHw+ISFkwPLwCZefwVjY+pqKg1qcK03+/4=
 go.uber.org/atomic v1.9.0 h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=
 go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
@@ -248,6 +256,7 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 gonum.org/v1/gonum v0.16.0 h1:5+ul4Swaf3ESvrOnidPp4GZbzf0mxVQpDCYUQE7OJfk=
 gonum.org/v1/gonum v0.16.0/go.mod h1:fef3am4MQ93R2HHpKnLk4/Tbh/s0+wqD5nfa6Pnwy4E=
 google.golang.org/genproto/googleapis/api v0.0.0-20260128011058-8636f8732409 h1:merA0rdPeUV3YIIfHHcH4qBkiQAc1nfCKSI7lB4cV2M=
+google.golang.org/genproto/googleapis/api v0.0.0-20260128011058-8636f8732409/go.mod h1:fl8J1IvUjCilwZzQowmw2b7HQB2eAuYBabMXzWurF+I=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260128011058-8636f8732409 h1:H86B94AW+VfJWDqFeEbBPhEtHzJwJfTbgE2lZa54ZAQ=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260128011058-8636f8732409/go.mod h1:j9x/tPzZkyxcgEFkiKEEGxfvyumM01BEtsW8xzOahRQ=
 google.golang.org/grpc v1.78.0 h1:K1XZG/yGDJnzMdd/uZHAkVqJE+xIDOcmdSFZkBUicNc=

--- a/httpmanager/go.mod
+++ b/httpmanager/go.mod
@@ -3,7 +3,7 @@ module github.com/SALT-Indonesia/salt-pkg/httpmanager
 go 1.24.0
 
 require (
-	github.com/SALT-Indonesia/salt-pkg/logmanager v1.43.1
+	github.com/SALT-Indonesia/salt-pkg/logmanager v1.44.0
 	github.com/gorilla/mux v1.8.1
 	github.com/stretchr/testify v1.11.1
 )

--- a/httpmanager/go.sum
+++ b/httpmanager/go.sum
@@ -1,5 +1,7 @@
 github.com/SALT-Indonesia/salt-pkg/logmanager v1.43.1 h1:r6tC5g3J2G62INK3vnFSJ0FZ8XbyTcaZOcA3tB9QmUk=
 github.com/SALT-Indonesia/salt-pkg/logmanager v1.43.1/go.mod h1:Y/MycoisUMyxYtI8+wyHS62h5ga6LgvdrOXCIZ7BrSA=
+github.com/SALT-Indonesia/salt-pkg/logmanager v1.44.0 h1:cUjNhpv/9wMEsTM91NdzLm+Z+xunN1I0ppgdOWSbp58=
+github.com/SALT-Indonesia/salt-pkg/logmanager v1.44.0/go.mod h1:Y/MycoisUMyxYtI8+wyHS62h5ga6LgvdrOXCIZ7BrSA=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=


### PR DESCRIPTION
## Summary

Bumps the `github.com/SALT-Indonesia/salt-pkg/logmanager` dependency from `v1.43.1` to **`v1.44.0`** in the modules that consume it, so they pick up the new wildcard/prefix support in `WithExposeHeaders` (e.g. `"CF-*"`) released in logmanager/v1.44.0 (#73).

## Changes

`go.mod` + `go.sum` updated in:
- `clientmanager`
- `eventmanager`
- `httpmanager`
- `examples`

`examples/otel-example` (a separate nested module pinned at `v1.41.0`) is left untouched, matching the scope of the previous bump (#71).

## Verification

- `go test ./logmanager/... ./httpmanager/... ./clientmanager/... ./eventmanager/...` — all pass
- Standalone `GOWORK=off go build ./...` succeeds for clientmanager, eventmanager, httpmanager (confirms `go.sum` hashes resolve the published tag)
- `go build ./examples/...` — ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)