### PR TITLE
Upgrade Go toolchain to 1.26.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,7 +66,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.24'
+        go-version: '1.26'
 
     - name: Cache Go modules
       uses: actions/cache@v4
@@ -101,7 +101,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.24'
+        go-version: '1.26'
 
     - name: Download vendor directory
       uses: actions/download-artifact@v4
@@ -132,7 +132,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.24'
+        go-version: '1.26'
 
     - name: Download vendor directory
       uses: actions/download-artifact@v4
@@ -194,7 +194,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.24'
+        go-version: '1.26'
 
     - name: Download vendor directory
       uses: actions/download-artifact@v4
@@ -225,7 +225,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.24'
+        go-version: '1.26'
 
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v8
@@ -247,7 +247,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.24'
+        go-version: '1.26'
 
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v8
@@ -291,7 +291,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.24'
+        go-version: '1.26'
 
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v8
@@ -305,10 +305,8 @@ jobs:
     needs: changes
     if: needs.changes.outputs.clientmanager == 'true'
     runs-on: ubuntu-latest
-    # Advisory only: remaining govulncheck findings are Go standard-library
-    # vulnerabilities with no fix available on Go 1.24 (the fixes require
-    # Go 1.25+). Keep the scan visible but non-blocking; drop this when the
-    # Go toolchain is upgraded.
+    # Advisory only: kept non-blocking after the Go 1.26 upgrade until a scan
+    # confirms the previously flagged standard-library findings are resolved.
     continue-on-error: true
 
     steps:
@@ -318,7 +316,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.24'
+        go-version: '1.26'
 
     - name: Install govulncheck
       run: go install golang.org/x/vuln/cmd/govulncheck@latest
@@ -332,10 +330,8 @@ jobs:
     needs: changes
     if: needs.changes.outputs.httpmanager == 'true'
     runs-on: ubuntu-latest
-    # Advisory only: remaining govulncheck findings are Go standard-library
-    # vulnerabilities with no fix available on Go 1.24 (the fixes require
-    # Go 1.25+). Keep the scan visible but non-blocking; drop this when the
-    # Go toolchain is upgraded.
+    # Advisory only: kept non-blocking after the Go 1.26 upgrade until a scan
+    # confirms the previously flagged standard-library findings are resolved.
     continue-on-error: true
 
     steps:
@@ -345,7 +341,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.24'
+        go-version: '1.26'
 
     - name: Install govulncheck
       run: go install golang.org/x/vuln/cmd/govulncheck@latest
@@ -386,10 +382,8 @@ jobs:
     needs: changes
     if: needs.changes.outputs.eventmanager == 'true'
     runs-on: ubuntu-latest
-    # Advisory only: remaining govulncheck findings are Go standard-library
-    # vulnerabilities with no fix available on Go 1.24 (the fixes require
-    # Go 1.25+). Keep the scan visible but non-blocking; drop this when the
-    # Go toolchain is upgraded.
+    # Advisory only: kept non-blocking after the Go 1.26 upgrade until a scan
+    # confirms the previously flagged standard-library findings are resolved.
     continue-on-error: true
 
     steps:
@@ -399,7 +393,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.24'
+        go-version: '1.26'
 
     - name: Install govulncheck
       run: go install golang.org/x/vuln/cmd/govulncheck@latest

--- a/clientmanager/go.mod
+++ b/clientmanager/go.mod
@@ -1,6 +1,6 @@
 module github.com/SALT-Indonesia/salt-pkg/clientmanager
 
-go 1.25.12
+go 1.26.0
 
 require (
 	github.com/Azure/go-ntlmssp v0.1.1

--- a/eventmanager/go.mod
+++ b/eventmanager/go.mod
@@ -1,6 +1,6 @@
 module github.com/SALT-Indonesia/salt-pkg/eventmanager
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/SALT-Indonesia/salt-pkg/logmanager v1.44.0

--- a/go.work
+++ b/go.work
@@ -1,4 +1,4 @@
-go 1.25.12
+go 1.26.0
 
 use (
 	./clientmanager

--- a/httpmanager/go.mod
+++ b/httpmanager/go.mod
@@ -1,6 +1,6 @@
 module github.com/SALT-Indonesia/salt-pkg/httpmanager
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/SALT-Indonesia/salt-pkg/logmanager v1.44.0

--- a/httpmanager/handler.go
+++ b/httpmanager/handler.go
@@ -157,7 +157,7 @@ func checkCustomErrorV2(err error) (bool, int, interface{}) {
 	errValue := reflect.ValueOf(err)
 	
 	// Dereference pointer if necessary
-	if errValue.Kind() == reflect.Ptr {
+	if errValue.Kind() == reflect.Pointer {
 		errValue = errValue.Elem()
 	}
 	
@@ -200,7 +200,7 @@ func checkResponseSuccess(resp interface{}) (bool, int, interface{}) {
 	respValue := reflect.ValueOf(resp)
 
 	// Dereference pointer if necessary
-	if respValue.Kind() == reflect.Ptr {
+	if respValue.Kind() == reflect.Pointer {
 		respValue = respValue.Elem()
 	}
 

--- a/httpmanager/query_param.go
+++ b/httpmanager/query_param.go
@@ -85,7 +85,7 @@ func BindQueryParams(ctx context.Context, dst interface{}) error {
 
 	// Get the value and type of the destination
 	dstValue := reflect.ValueOf(dst)
-	if dstValue.Kind() != reflect.Ptr {
+	if dstValue.Kind() != reflect.Pointer {
 		return nil // Must be a pointer to struct
 	}
 


### PR DESCRIPTION
## Summary
Upgrades the Go toolchain version from 1.25.x to 1.26.0 across all modules and CI/CD workflows.

## Key Changes
- Updated `go.work` to specify Go 1.26.0
- Updated all module `go.mod` files (clientmanager, httpmanager, eventmanager) to Go 1.26.0
- Updated all GitHub Actions workflows to use Go 1.26 in the setup-go action
- Updated govulncheck advisory comments to reflect the Go 1.26 upgrade and indicate that standard-library vulnerability findings should be re-evaluated with the new toolchain

## Notable Details
The govulncheck jobs remain non-blocking (`continue-on-error: true`) pending confirmation that previously flagged standard-library vulnerabilities are resolved with Go 1.26, as the fixes for those issues required upgrading from Go 1.24.

https://claude.ai/code/session_01XQXHwbMzThiT93qhDtRn7B